### PR TITLE
Various clean up around race conditions and exception handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ buildSrc/libs
 buildSrc/build/
 .gradle/
 build
+build/
 .idea/
 !.idea/codeStyles/codeStyleConfig.xml
 .DS_Store
@@ -9,3 +10,4 @@ build
 out/
 buildSrc/es-knn-offline-repo-*
 oss/*
+*.iml

--- a/jni/src/v1736/com_amazon_opendistroforelasticsearch_knn_index_v1736_KNNIndex.cpp
+++ b/jni/src/v1736/com_amazon_opendistroforelasticsearch_knn_index_v1736_KNNIndex.cpp
@@ -184,7 +184,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_amazon_opendistroforelasticsearch_knn_in
     return NULL;
 }
 
-JNIEXPORT jlong JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v1736_KNNIndex_init(JNIEnv* env, jobject indexObject, jstring indexPath)
+JNIEXPORT jlong JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v1736_KNNIndex_init(JNIEnv* env, jstring indexPath)
 {
     Space<float>* space = NULL;
     ObjectVector* dataset = NULL;
@@ -200,11 +200,11 @@ JNIEXPORT jlong JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v17
         env->ReleaseStringUTFChars(indexPath, indexString);
         has_exception_in_stack(env);
 
-        return (jlong) index;
-
         // free up memory
         delete space;
         delete dataset;
+
+        return (jlong) index;
     }
     catch (...) {
         if (space) { delete space; }

--- a/jni/src/v1736/com_amazon_opendistroforelasticsearch_knn_index_v1736_KNNIndex.h
+++ b/jni/src/v1736/com_amazon_opendistroforelasticsearch_knn_index_v1736_KNNIndex.h
@@ -36,15 +36,15 @@ JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v173
  * Signature: ([FI[Ljava/lang/String;)[Lcom/amazon/opendistroforelasticsearch/knn/index/KNNQueryResult;
  */
 JNIEXPORT jobjectArray JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v1736_KNNIndex_queryIndex
-  (JNIEnv *, jobject, jfloatArray, jint, jobjectArray);
+  (JNIEnv *, jlong, jfloatArray, jint, jobjectArray);
 
 /*
  * Class:     com_amazon_opendistroforelasticsearch_knn_index_v1736_KNNIndex
  * Method:    init
  * Signature: (Ljava/lang/String;)V
  */
-JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v1736_KNNIndex_init
-  (JNIEnv *, jobject, jstring);
+JNIEXPORT jlong JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v1736_KNNIndex_init
+  (JNIEnv *, jstring);
 
 /*
  * Class:     com_amazon_opendistroforelasticsearch_knn_index_v1736_KNNIndex
@@ -52,7 +52,7 @@ JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v173
  * Signature: ()V
  */
 JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v1736_KNNIndex_gc
-  (JNIEnv *, jobject);
+  (JNIEnv *, jlong);
 
 #ifdef __cplusplus
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNIndexFileListener.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNIndexFileListener.java
@@ -38,16 +38,10 @@ public class KNNIndexFileListener implements FileChangesListener {
     }
 
     public void register(Path filePath) throws Exception {
-
         final FileWatcher watcher = new FileWatcher(filePath);
         watcher.addListener(this);
         watcher.init();
-        try {
-            resourceWatcherService.add(watcher, ResourceWatcherService.Frequency.HIGH);
-
-        } catch (IOException e) {
-            logger.error("couldn't initialize resource watcher for file " + filePath.toString(), e);
-        }
+        resourceWatcherService.add(watcher, ResourceWatcherService.Frequency.HIGH);
         logger.debug("[KNN] Registered file {}", filePath.toString());
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/v1736/KNNIndex.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/v1736/KNNIndex.java
@@ -85,6 +85,7 @@ public class KNNIndex implements AutoCloseable {
     @Override
     public void close() {
         Lock writeLock = readWriteLock.writeLock();
+        writeLock.lock();
         try {
             gc(this.indexPointer);
         } finally {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNJNIIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNJNIIT.java
@@ -91,15 +91,8 @@ public class KNNJNIIT extends ESIntegTestCase {
         float[] queryVector = {1.0f, 1.0f, 1.0f, 1.0f};
         String[] algoQueryParams = {"efSearch=20"};
 
-        KNNQueryResult[] results = AccessController.doPrivileged(
-                new PrivilegedAction<KNNQueryResult[]>() {
-                    public KNNQueryResult[] run() {
-                        KNNIndex index = KNNIndex.loadIndex(indexPath.toString());
-                        logger.info(index.getIndex());
-                        return index.queryIndex(queryVector, 30, algoQueryParams);
-                    }
-                }
-        );
+        final KNNIndex knnIndex = KNNIndex.loadIndex(indexPath);
+        final KNNQueryResult[] results = knnIndex.queryIndex(queryVector, 30, algoQueryParams);
 
         Map<Integer, Float> scores = Arrays.stream(results).collect(
                 Collectors.toMap(result -> result.getId(), result -> result.getScore()));
@@ -171,15 +164,9 @@ public class KNNJNIIT extends ESIntegTestCase {
 
         float[] queryVector = {1.0f, 1.0f, 1.0f, 1.0f};
         String[] algoQueryParams = {"efSearch=200"};
-        KNNQueryResult[] results = AccessController.doPrivileged(
-                new PrivilegedAction<KNNQueryResult[]>() {
-                    public KNNQueryResult[] run() {
-                        KNNIndex index = KNNIndex.loadIndex(indexPath.toString());
-                        logger.info(index.getIndex());
-                        return index.queryIndex(queryVector, 30, algoQueryParams);
-                    }
-                }
-        );
+
+        final KNNIndex index = KNNIndex.loadIndex(indexPath);
+        final KNNQueryResult[] results = index.queryIndex(queryVector, 30, algoQueryParams);
 
         Map<Integer, Float> scores = Arrays.stream(results).collect(
                 Collectors.toMap(result -> result.getId(), result -> result.getScore()));


### PR DESCRIPTION
### Motivation
While running some load tests using the KNN Plugin, we encountered an Elasticsearch node crash. We don't have access to the crash logs on our end, but during the event we were running around 5,000 queries per second to various (on the order of a couple hundred) KNN indexes in the cluster, as well as running workflows which actively restore pre-built KNN indexes onto the cluster, run search queries against those indexes, and delete indexes which are no longer necessary (which also receive query traffic right up until the point at which they are deleted). 

### Description of changes

1. Remove all calls from c++ to KNN Index java, instead having init() return the index pointer and queryIndex() and gc() accept the index pointer
2. Add read write lock to KNN index java to allow parallel queries but not while index is being closed (which applies a write lock). Upon proceeding with the read lock, queries throw an IOException if the index has been closed while they were waiting.
3. Simplify exception semantics so that unexpected failure modes (e.g. bad alloc due to OOM) are left unhandled and lead to expected process crashes, while expected scenarios (execution of a query just after gc) leads to a proper checked exception (IOException)
4. Make sure call to gc() occurs first in case there's some exception thrown in onRemoval code prior to it