### PR TITLE
Add IndexWrapper to JNI code to reduce manual memory management and recreation of space on queries

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/v1736/KNNIndex.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/v1736/KNNIndex.java
@@ -87,6 +87,12 @@ public class KNNIndex implements AutoCloseable {
     public void close() {
         Lock writeLock = readWriteLock.writeLock();
         writeLock.lock();
+
+        // Autocloseable documentation recommends making close idempotent. We don't expect to doubly close
+        // but this will help prevent a crash in that situation.
+        if (this.isClosed) {
+            return;
+        }
         try {
             gc(this.indexPointer);
         } finally {


### PR DESCRIPTION
Note: Supercedes https://github.com/opendistro-for-elasticsearch/k-NN/pull/38


### Description
This change adds IndexWrapper into the JNI layer similar to how nmslib does it in their python bindings. This avoids the need to recreate the space on all queries as well as provides automatic deletion upon deletion of the IndexWrapper.
