### PR TITLE
added reading from stream input for KNN stats request

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/transport/KNNStatsNodeRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/transport/KNNStatsNodeRequest.java
@@ -42,7 +42,7 @@ class KNNStatsNodeRequest extends BaseNodeRequest {
      */
     public KNNStatsNodeRequest(StreamInput in) throws IOException {
         super(in);
-        request = new KNNStatsRequest();
+        request = new KNNStatsRequest(in);
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*
#45 
*Description of changes:*
Minor fix to read from StreamInput for KNNStatsRequest in KNNStatsNodeRequest. 

Verified fix worked by spinning up 2 node cluster and checking stats output. 

RestKNNStatsHandlerIT should run on multiple node cluster instead of single node to catch issues related to Transport Layer. #46 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
