### PR TITLE
fixed issue with test footer test case

### DIFF
--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNN80HnswIndexTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNN80HnswIndexTests.java
@@ -83,7 +83,7 @@ public class KNN80HnswIndexTests extends ESTestCase {
         CodecUtil.checkFooter(indexInput); // If footer is not valid, it would throw exception and test fails
         indexInput.close();
 
-        IndexSearcher searcher = newSearcher(reader);
+        IndexSearcher searcher = new IndexSearcher(reader);
         assertEquals(1, searcher.count(new KNNQuery("test_vector", new float[] {1.0f, 2.5f}, 1, "myindex")));
 
         reader.close();
@@ -121,7 +121,6 @@ public class KNN80HnswIndexTests extends ESTestCase {
         Document doc1 = new Document();
         doc1.add(vectorField1);
         writer.addDocument(doc1);
-
         KNNIndexCache.setResourceWatcherService(createDisabledResourceWatcherService());
         IndexReader reader = writer.getReader();
         List<String> hnswfiles = Arrays.stream(dir.listAll()).filter(x -> x.contains("hnsw")).collect(Collectors.toList());
@@ -132,7 +131,7 @@ public class KNN80HnswIndexTests extends ESTestCase {
         assertEquals(hnswfiles.stream().filter(x -> x.contains("my_vector")).collect(Collectors.toList()).size(), 1);
 
         // query to verify distance for each of the field
-        IndexSearcher searcher = newSearcher(reader);
+        IndexSearcher searcher = new IndexSearcher(reader);
         float score = searcher.search(new KNNQuery("test_vector", new float[] {1.0f, 0.0f, 0.0f}, 1, "dummy"), 10).scoreDocs[0].score;
         float score1 = searcher.search(new KNNQuery("my_vector", new float[] {1.0f, 2.0f}, 1, "dummy"), 10).scoreDocs[0].score;
         assertEquals(score, 0.1667f, 0.01f);


### PR DESCRIPTION
*Issue #, if available:*
#65 
*Description of changes:*
Fixed rare test failure in testFooter. To get the `indexSearcher`, we were using a method from Lucene Test Case called `newSearcher`. `newSearcher` uses randomization when testing. `newSearcher` calls `maybeWrapReader`, which "rarely" calls `wrapReader`. In `wrapReader`, it sometimes wraps the reader with `ParallelLeafReader`, which is not ES compatible.

So, the solution is to call the IndexSearcher constructor instead of `newSearcher.`
`
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
