### PR TITLE
k-NN CI/CD GitHub Actions

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,0 +1,42 @@
+name: Build and Release k-NN
+on:
+  push:
+    tags: 
+      - v*
+
+jobs:
+  Build-k-NN:
+    strategy:
+      matrix:
+        java: [12]
+
+    name: Build and Release k-NN Plugin
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout k-NN
+        uses: actions/checkout@v1
+        
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      
+      - name: Run build
+        run: |
+          ./gradlew build buildDeb buildRpm --console=plain -Dbuild.snapshot=false
+          artifact=`ls build/distributions/*.zip`
+          rpm_artifact=`ls build/distributions/*.rpm`
+          deb_artifact=`ls build/distributions/*.deb`
+          
+          aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-plugins/opendistro-knn/
+          aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-knn/
+          aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-knn/
+          aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -31,7 +31,7 @@ jobs:
       
       - name: Run build
         run: |
-          ./gradlew build buildDeb buildRpm --console=plain -Dbuild.snapshot=false
+          ./gradlew release --console=plain -Dbuild.snapshot=false
           artifact=`ls build/distributions/*.zip`
           rpm_artifact=`ls build/distributions/*.rpm`
           deb_artifact=`ls build/distributions/*.deb`

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,14 +1,14 @@
 name: Build and Release k-NN
 on:
   push:
-    tags: 
+    tags:
       - v*
 
 jobs:
   Build-k-NN:
     strategy:
       matrix:
-        java: [12]
+        java: [13]
 
     name: Build and Release k-NN Plugin
     runs-on: ubuntu-latest
@@ -16,26 +16,26 @@ jobs:
     steps:
       - name: Checkout k-NN
         uses: actions/checkout@v1
-        
+
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-      
+
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      
+
       - name: Run build
         run: |
           ./gradlew release --console=plain -Dbuild.snapshot=false
           artifact=`ls build/distributions/*.zip`
           rpm_artifact=`ls build/distributions/*.rpm`
           deb_artifact=`ls build/distributions/*.deb`
-          
+
           aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-plugins/opendistro-knn/
           aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-knn/
           aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-knn/

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
   Build-k-NN:
     strategy:
       matrix:
-        java: [12]
+        java: [13]
 
     name: Build and Test k-NN Plugin
     runs-on: ubuntu-latest
@@ -17,17 +17,17 @@ jobs:
     steps:
       - name: Checkout k-NN
         uses: actions/checkout@v1
-        
+
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      
+
       - name: Run build
         run: |
           ./gradlew build
           ls -ltr build/distributions/
-          
+
       - name: Pull and Run Docker
         run: |
           plugin=`ls build/distributions/*.zip`
@@ -35,28 +35,28 @@ jobs:
           plugin_version=`echo $plugin|awk -F- '{print $3}'| cut -d. -f 1-4`
           echo $version
           cd ..
-          
+
           if docker pull opendistroforelasticsearch/opendistroforelasticsearch:$version
           then
             echo "FROM opendistroforelasticsearch/opendistroforelasticsearch:$version" >> Dockerfile
-            
-            ## The ESRestTest Client uses http by default. 
+
+            ## The ESRestTest Client uses http by default.
             ## Need to disable the security plugin to call the rest api over http.
             echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro_security ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_security; fi" >> Dockerfile
             echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro-knn ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-knn; fi" >> Dockerfile
             echo "ADD k-NN/build/distributions/opendistro-knn-$plugin_version.zip /tmp/" >> Dockerfile
             echo "RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:/tmp/opendistro-knn-$plugin_version.zip" >> Dockerfile
-            
+
             docker build -t odfe-knn:test .
           fi
-          
+
       - name: Run Docker Image
         run: |
           cd ..
           docker run -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" odfe-knn:test
           sleep 15
           curl -XGET http://localhost:9200/_cat/plugins
-          
+
       - name: Run k-NN Test
         run: |
           ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,59 @@
+name: Build and Test k-NN
+on:
+  push:
+    branches:
+      - master
+      - opendistro-*
+
+jobs:
+  Build-k-NN:
+    strategy:
+      matrix:
+        java: [12]
+
+    name: Build and Test k-NN Plugin
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout k-NN
+        uses: actions/checkout@v1
+        
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      
+      - name: Run build
+        run: |
+          ./gradlew build
+          ls -ltr build/distributions/
+          
+      - name: Pull and Run Docker
+        run: |
+          plugin=`ls build/distributions/*.zip`
+          version=`echo $plugin|awk -F- '{print $3}'| cut -d. -f 1-3`
+          plugin_version=`echo $plugin|awk -F- '{print $3}'| cut -d. -f 1-4`
+          echo $version
+          cd ..
+          
+          if docker pull opendistroforelasticsearch/opendistroforelasticsearch:$version
+          then
+            echo "FROM opendistroforelasticsearch/opendistroforelasticsearch:$version" >> Dockerfile
+            echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro_security ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_security; fi" >> Dockerfile
+            echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro-knn ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-knn; fi" >> Dockerfile
+            echo "ADD k-NN/build/distributions/opendistro-knn-$plugin_version.zip /tmp/" >> Dockerfile
+            echo "RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:/tmp/opendistro-knn-$plugin_version.zip" >> Dockerfile
+            
+            docker build -t odfe-knn:test .
+          fi
+          
+      - name: Run Docker Image
+        run: |
+          cd ..
+          docker run -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" odfe-knn:test
+          sleep 15
+          curl -XGET http://localhost:9200/_cat/plugins
+          
+      - name: Run k-NN Test
+        run: |
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,6 +39,9 @@ jobs:
           if docker pull opendistroforelasticsearch/opendistroforelasticsearch:$version
           then
             echo "FROM opendistroforelasticsearch/opendistroforelasticsearch:$version" >> Dockerfile
+            
+            ## The ESRestTest Client uses http by default. 
+            ## Need to disable the security plugin to call the rest api over http.
             echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro_security ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_security; fi" >> Dockerfile
             echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro-knn ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-knn; fi" >> Dockerfile
             echo "ADD k-NN/build/distributions/opendistro-knn-$plugin_version.zip /tmp/" >> Dockerfile


### PR DESCRIPTION
Issue #74 
###CI.yml

This job will trigger on every code checkin in master and opendistro branches which then will build the k-NN plugin and run integration tests against the respective version of opendistro staging docker image.
Before running the test the job will first remove k-NN plugin, if available, then it will re-install the built plugin.

###CD.yml
This job will trigger whenever a code checkin is made on an opendistro branch or a new opendistro branch is cut. It will build all the artifacts and then upload to respective S3 paths.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
