### PR TITLE
fix npe

### DIFF
--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNRestTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNRestTestCase.java
@@ -73,7 +73,7 @@ public class KNNRestTestCase extends ESRestTestCase {
         // jacoco.dir is set in esplugin-coverage.gradle, if it doesn't exist we don't
         // want to collect coverage so we can return early
         String jacocoBuildPath = System.getProperty("jacoco.dir");
-        if (jacocoBuildPath.isEmpty()) {
+        if (jacocoBuildPath == null || jacocoBuildPath.isEmpty()) {
             return;
         }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNRestTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNRestTestCase.java
@@ -73,7 +73,7 @@ public class KNNRestTestCase extends ESRestTestCase {
         // jacoco.dir is set in esplugin-coverage.gradle, if it doesn't exist we don't
         // want to collect coverage so we can return early
         String jacocoBuildPath = System.getProperty("jacoco.dir");
-        if (jacocoBuildPath == null || jacocoBuildPath.isEmpty()) {
+        if (Strings.isNullOrEmpty(jacocoBuildPath)) {
             return;
         }
 


### PR DESCRIPTION
*Issue #, if available:*
#71 

*Description of changes:*
When running against a remote cluster, the current tests would throw an NPE because of a null String. This PR fixes that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
