### PR TITLE
fixed debugging functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ The package uses the [Gradle](https://docs.gradle.org/5.5.1/userguide/userguide.
 
 ### Debugging
 
-Sometimes it is useful to attach a debugger to either the Elasticsearch cluster or the integ tests to see what's going on. When running unit tests, hit **Debug** from the IDE's gutter to debug the tests.  For the Elasticsearch cluster or the integ tests, first, make sure that the debugger is listening on port `5005`. Then, to debug the server  code, run:
+Sometimes it is useful to attach a debugger to either the Elasticsearch cluster or the integration test runner to see what's going on. For running unit tests, hit **Debug** from the IDE's gutter to debug the tests. For the Elasticsearch cluster, first, make sure that the debugger is listening on port `5005`. Then, to debug the cluster code, run:
 
 ```
-./gradlew :integTest -Ddebug.es=1 # to start a cluster and run integ tests
+./gradlew :integTest -Dcluster.debug=1 # to start a cluster with debugger and run integ tests
 ```
 
 OR
@@ -36,13 +36,18 @@ OR
 
 The Elasticsearch server JVM will connect to a debugger attached to `localhost:5005` before starting.
 
-To debug code running in an integ test (which exercises the server from a separate JVM), run:
+To debug code running in an integration test (which exercises the server from a separate JVM), first, setup a remote debugger listening on port `8000`, and then run:
 
 ```
-./gradlew -Dtest.debug=1 integTest
+./gradlew :integTest -Dtest.debug=1 
 ```
 
-The test runner JVM will start connect to a debugger attached to `localhost:5005` before running the tests
+The test runner JVM will connect to a debugger attached to `localhost:8000` before running the tests.
+
+Additionally, it is possible to attach one debugger to the cluster JVM and another debugger to the test runner. First, make sure one debugger is listening on port `5005` and the other is listening on port `8000`. Then, run:
+```
+./gradlew :integTest -Dtest.debug=1 -Dcluster.debug=1
+```
 
 ## Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ The package uses the [Gradle](https://docs.gradle.org/5.5.1/userguide/userguide.
 
 ### Debugging
 
-Sometimes it's useful to attach a debugger to either the Elasticsearch cluster or the integ tests to see what's going on. When running unit tests, hit **Debug** from the IDE's gutter to debug the tests.  To debug code running in an actual server, run:
+Sometimes it is useful to attach a debugger to either the Elasticsearch cluster or the integ tests to see what's going on. When running unit tests, hit **Debug** from the IDE's gutter to debug the tests.  For the Elasticsearch cluster or the integ tests, first, make sure that the debugger is listening on port `5005`. Then, to debug the server  code, run:
 
 ```
-./gradlew :integTest --debug-jvm # to start a cluster and run integ tests
+./gradlew :integTest -Ddebug.es=1 # to start a cluster and run integ tests
 ```
 
 OR
@@ -34,7 +34,7 @@ OR
 ./gradlew run --debug-jvm # to just start a cluster that can be debugged
 ```
 
-The Elasticsearch server JVM will launch suspended and wait for a debugger to attach to `localhost:8000` before starting the Elasticsearch server.
+The Elasticsearch server JVM will connect to a debugger attached to `localhost:5005` before starting.
 
 To debug code running in an integ test (which exercises the server from a separate JVM), run:
 
@@ -42,7 +42,7 @@ To debug code running in an integ test (which exercises the server from a separa
 ./gradlew -Dtest.debug=1 integTest
 ```
 
-The test runner JVM will start suspended and wait for a debugger to attach to `localhost:5005` before running the tests
+The test runner JVM will start connect to a debugger attached to `localhost:5005` before running the tests
 
 ## Basic Usage
 

--- a/build.gradle
+++ b/build.gradle
@@ -115,15 +115,9 @@ integTest {
         systemProperty 'tests.security.manager', 'false'
         systemProperty 'java.io.tmpdir', es_tmp_dir.absolutePath
 
-        // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
-        // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
-        doFirst {
-            systemProperty 'cluster.debug', System.getProperty("debug.es")
-        }
-
         // The -Ddebug.es option makes the cluster debuggable; this makes the tests debuggable
         if (System.getProperty("test.debug") != null) {
-            jvmArgs '-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=5005'
+            jvmArgs '-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=8000'
         }
 
         systemProperty "java.library.path", "$rootDir/buildSrc"
@@ -134,7 +128,7 @@ integTest {
 
 testClusters.integTest {
         testDistribution = "OSS"
-        if (System.getProperty("debug.es") != null) {
+        if (System.getProperty("cluster.debug") != null) {
             jvmArgs('-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=5005')
         }
         systemProperty("java.library.path", "$rootDir/buildSrc")

--- a/build.gradle
+++ b/build.gradle
@@ -117,11 +117,13 @@ integTest {
 
         // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
         // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
-        doFirst { systemProperty 'cluster.debug', getDebug() }
+        doFirst {
+            systemProperty 'cluster.debug', System.getProperty("debug.es")
+        }
 
-        // The --debug-jvm command-line option makes the cluster debuggable; this makes the tests debuggable
+        // The -Ddebug.es option makes the cluster debuggable; this makes the tests debuggable
         if (System.getProperty("test.debug") != null) {
-            jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
+            jvmArgs '-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=5005'
         }
 
         systemProperty "java.library.path", "$rootDir/buildSrc"
@@ -132,6 +134,9 @@ integTest {
 
 testClusters.integTest {
         testDistribution = "OSS"
+        if (System.getProperty("debug.es") != null) {
+            jvmArgs('-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=5005')
+        }
         systemProperty("java.library.path", "$rootDir/buildSrc")
 }
 


### PR DESCRIPTION
*Issue #, if available:*
#77 
*Description of changes:*
This PR fixes a bug preventing a debugger from being able to attach to the integration test server and updates the documentation. In prior Elasticsearch versions, it was possible to run the command `./gradlew integTests --debug-jvm` to connect the debugger to the integTests server. For ES 7.6, this is no longer possible. Now, we pass the JVM args to the integration tests server manually.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
