### PR TITLE
change package building command

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run build
         run: |
-          ./gradlew release --console=plain -Dbuild.snapshot=false
+          ./gradlew buildPackages --console=plain -Dbuild.snapshot=false
           artifact=`ls build/distributions/*.zip`
           rpm_artifact=`ls build/distributions/*.rpm`
           deb_artifact=`ls build/distributions/*.deb`


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
CD was failing because `./gradlew release`  does not build the artifacts. This change switches the command to `./gradlew buildPackages`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
