### PR TITLE
Add cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ out/
 buildSrc/es-knn-offline-repo-*
 oss/*
 *.iml
+jni/CMakeCache.txt
+jni/CMakeFiles
+jni/Makefile
+jni/cmake_install.cmake

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "jni/external/nmslib"]
+	path = jni/external/nmslib
+	url = https://github.com/nmslib/nmslib.git

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ The package uses the [Gradle](https://docs.gradle.org/5.5.1/userguide/userguide.
 2. To build from command line set `JAVA_HOME` to point to a JDK >=12
 3. Run `./gradlew build`
 
+## Building JNI Library
+
+To build the JNI Library used to incorporate NMSLIB functionality, follow these steps:
+
+```
+cd jni
+cmake .
+make
+``` 
+
+The library will be placed in the `buildSrc` directory.
+
 ### Debugging
 
 Sometimes it is useful to attach a debugger to either the Elasticsearch cluster or the integration test runner to see what's going on. For running unit tests, hit **Debug** from the IDE's gutter to debug the tests. For the Elasticsearch cluster, first, make sure that the debugger is listening on port `5005`. Then, to debug the cluster code, run:

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -1,3 +1,18 @@
+#
+#   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   A copy of the License is located at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   or in the "license" file accompanying this file. This file is distributed
+#   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#   express or implied. See the License for the specific language governing
+#   permissions and limitations under the License.
+#
+
 cmake_minimum_required(VERSION 2.8)
 
 project(KNNIndexV1_7_3_6)

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -33,7 +33,7 @@ if (NOT EXISTS ${NMS_REPO_DIR})
 endif ()
 
 # Add the subdirectory so it is possible to use its targets
-add_subdirectory(external/nmslib/similarity_search)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/external/nmslib/similarity_search)
 
 # Set OS specific variables
 if (${CMAKE_SYSTEM_NAME} STREQUAL Darwin)

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(KNNIndexV1_7_3_6)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+# Target Library to be built
+set(KNN_INDEX KNNIndexV1_7_3_6)
+
+find_path(NMS_REPO_DIR NAMES nmslib PATHS ${CMAKE_CURRENT_SOURCE_DIR}/external REQUIRED)
+
+if (NOT EXISTS ${NMS_REPO_DIR})
+    message(STATUS "Could not find nmslib. Pulling updating submodule.")
+    execute_process(COMMAND git submodule update --init -- external/nmslib WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endif ()
+
+## Check if nmslib is built and if not build it
+#find_library(NMS_LIB NAMES libNonMetricSpaceLib.a  PATHS ${CMAKE_CURRENT_SOURCE_DIR}/external/nmslib/similarity_search/release REQUIRED)
+
+add_subdirectory(external/nmslib/similarity_search)
+
+if (${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
+    set(JVM_OS_TYPE darwin)
+    set(LIB_EXT .jnilib)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL Linux)
+    set(JVM_OS_TYPE linux)
+    set(LIB_EXT .so)
+else()
+    message( FATAL_ERROR "Unable to run on system: ${CMAKE_SYSTEM_NAME}")
+endif()
+
+# Build knn lib
+add_library(${KNN_INDEX} SHARED ${CMAKE_CURRENT_SOURCE_DIR}/src/v1736/com_amazon_opendistroforelasticsearch_knn_index_v1736_KNNIndex.cpp)
+target_link_libraries(${KNN_INDEX} NonMetricSpaceLib)
+target_include_directories(${KNN_INDEX} PRIVATE $ENV{JAVA_HOME}/include $ENV{JAVA_HOME}/include/${JVM_OS_TYPE} ${CMAKE_CURRENT_SOURCE_DIR}/external/nmslib/similarity_search/include)
+
+set_target_properties(${KNN_INDEX} PROPERTIES SUFFIX ${LIB_EXT})
+set_target_properties(${KNN_INDEX} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(${KNN_INDEX} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../buildSrc)

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 2.8)
 
 project(KNNIndexV1_7_3_6)
 
@@ -8,18 +8,19 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 # Target Library to be built
 set(KNN_INDEX KNNIndexV1_7_3_6)
 
-find_path(NMS_REPO_DIR NAMES nmslib PATHS ${CMAKE_CURRENT_SOURCE_DIR}/external REQUIRED)
+# Check if similarity search exists
+find_path(NMS_REPO_DIR NAMES similarity_search PATHS ${CMAKE_CURRENT_SOURCE_DIR}/external/nmslib REQUIRED)
 
+# If not, pull the updated submodule
 if (NOT EXISTS ${NMS_REPO_DIR})
-    message(STATUS "Could not find nmslib. Pulling updating submodule.")
+    message(STATUS "Could not find nmslib. Pulling updated submodule.")
     execute_process(COMMAND git submodule update --init -- external/nmslib WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif ()
 
-## Check if nmslib is built and if not build it
-#find_library(NMS_LIB NAMES libNonMetricSpaceLib.a  PATHS ${CMAKE_CURRENT_SOURCE_DIR}/external/nmslib/similarity_search/release REQUIRED)
-
+# Add the subdirectory so it is possible to use its targets
 add_subdirectory(external/nmslib/similarity_search)
 
+# Set OS specific variables
 if (${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
     set(JVM_OS_TYPE darwin)
     set(LIB_EXT .jnilib)
@@ -30,7 +31,7 @@ else()
     message( FATAL_ERROR "Unable to run on system: ${CMAKE_SYSTEM_NAME}")
 endif()
 
-# Build knn lib
+# Compile the library
 add_library(${KNN_INDEX} SHARED ${CMAKE_CURRENT_SOURCE_DIR}/src/v1736/com_amazon_opendistroforelasticsearch_knn_index_v1736_KNNIndex.cpp)
 target_link_libraries(${KNN_INDEX} NonMetricSpaceLib)
 target_include_directories(${KNN_INDEX} PRIVATE $ENV{JAVA_HOME}/include $ENV{JAVA_HOME}/include/${JVM_OS_TYPE} ${CMAKE_CURRENT_SOURCE_DIR}/external/nmslib/similarity_search/include)


### PR DESCRIPTION
*Issue #, if available:*
#17 

*Description of changes:*
This PR incorporates CMake to build the JNI library for ease of development. In order to build the library, it adds nmslib as a submodule. Note that this submodule is set to the commit from the tag `v1.7.3.6`

Running the following commands will build the library for the respective platform into `buildSrc`:
```
cd jni
cmake .
make
```

Along with this, I updated the README to reflect these changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
