### PR TITLE
Broken Test Cases

### DIFF
--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNN80Codec/KNN80CodecTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNN80Codec/KNN80CodecTests.java
@@ -17,7 +17,7 @@ package com.amazon.opendistroforelasticsearch.knn.index.codec.KNN80Codec;
 
 import com.amazon.opendistroforelasticsearch.knn.index.codec.KNNCodecTestCase;
 
-public class  KNN80CodecTest extends KNNCodecTestCase {
+public class  KNN80CodecTests extends KNNCodecTestCase {
 
     public void testFooter() throws Exception {
         testFooter(new KNN80Codec());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNN84Codec/KNN84CodecTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNN84Codec/KNN84CodecTests.java
@@ -17,7 +17,7 @@ package com.amazon.opendistroforelasticsearch.knn.index.codec.KNN84Codec;
 
 import com.amazon.opendistroforelasticsearch.knn.index.codec.KNNCodecTestCase;
 
-public class  KNN84CodecTest extends KNNCodecTestCase {
+public class  KNN84CodecTests extends KNNCodecTestCase {
 
     public void testFooter() throws Exception {
         testFooter(new KNN84Codec());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNNCodecTestCase.java
@@ -139,9 +139,9 @@ public class  KNNCodecTestCase extends ESTestCase {
         Document doc1 = new Document();
         doc1.add(vectorField1);
         writer.addDocument(doc1);
-        KNNIndexCache.setResourceWatcherService(createDisabledResourceWatcherService());
         IndexReader reader = writer.getReader();
         writer.close();
+        KNNIndexCache.setResourceWatcherService(createDisabledResourceWatcherService());
         List<String> hnswfiles = Arrays.stream(dir.listAll()).filter(x -> x.contains("hnsw")).collect(Collectors.toList());
 
         // there should be 2 hnsw index files created. one for test_vector and one for my_vector

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNNCodecTestCase.java
@@ -141,6 +141,7 @@ public class  KNNCodecTestCase extends ESTestCase {
         writer.addDocument(doc1);
         KNNIndexCache.setResourceWatcherService(createDisabledResourceWatcherService());
         IndexReader reader = writer.getReader();
+        writer.close();
         List<String> hnswfiles = Arrays.stream(dir.listAll()).filter(x -> x.contains("hnsw")).collect(Collectors.toList());
 
         // there should be 2 hnsw index files created. one for test_vector and one for my_vector
@@ -160,7 +161,6 @@ public class  KNNCodecTestCase extends ESTestCase {
         assertEquals(1, searcher.count(new KNNQuery("my_vector", new float[] {1.0f, 1.0f}, 1, "dummy")));
 
         reader.close();
-        writer.close();
         dir.close();
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
#67 

*Description of changes:*
testMultiFieldsKnnIndex Test case infrequently creates 4 index files instead of 2. This is because the writer is not closed right after the document is added so segments do not get merged. To fix this, this PR closes the writer after the document is added.

Additionally, the 2 codec test classes were incorrectly named. This prevents them from running during `gradlew build`. So, this PR renames them as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
