### PR TITLE
Add gradle functionality to create multi-node cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ To learn more, please see our [documentation](https://opendistro.github.io/for-e
 
 1. Check out the package from version control.
 2. Launch Intellij IDEA, choose **Import Project**, and select the `settings.gradle` file in the root of this package.
-3. To build from the command line, set `JAVA_HOME` to point to a JDK >= 12 before running `./gradlew`.
+3. To build from the command line, set `JAVA_HOME` to point to a JDK >= 13 before running `./gradlew`.
 
 ## Build
 
 The package uses the [Gradle](https://docs.gradle.org/5.5.1/userguide/userguide.html) build system.
 
 1. Checkout this package from version control.
-2. To build from command line set `JAVA_HOME` to point to a JDK >=12
+2. To build from command line set `JAVA_HOME` to point to a JDK >=13
 3. Run `./gradlew build`
 
 ## Building JNI Library
@@ -31,6 +31,20 @@ make
 ``` 
 
 The library will be placed in the `buildSrc` directory.
+
+## Running Multi-node Cluster Locally
+
+It can be useful to test and debug on a multi-node cluster. In order to launch a 3 node cluster with the KNN plugin installed, run the following command:
+
+```
+./gradlew run -PnumNodes=3
+```
+
+In order to run the integration tests with a 3 node cluster, run this command:
+
+```
+./gradlew :integTest -PnumNodes=3
+```
 
 ### Debugging
 
@@ -46,7 +60,7 @@ OR
 ./gradlew run --debug-jvm # to just start a cluster that can be debugged
 ```
 
-The Elasticsearch server JVM will connect to a debugger attached to `localhost:5005` before starting.
+The Elasticsearch server JVM will connect to a debugger attached to `localhost:5005` before starting. If there are multiple nodes, the servers will connect to debuggers listening on ports `5005, 5006, ...`
 
 To debug code running in an integration test (which exercises the server from a separate JVM), first, setup a remote debugger listening on port `8000`, and then run:
 

--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ testClusters.integTest {
         if (System.getProperty("cluster.debug") != null) {
             def debugPort = 5005
             nodes.forEach { node ->
-                node.jvmArgs("-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=*:${debugPort}")
+                node.jvmArgs("-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=${debugPort}")
                 debugPort += 1
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,13 @@ plugins {
 
 apply plugin: 'elasticsearch.esplugin'
 
+def usingRemoteCluster = System.properties.containsKey('tests.rest.cluster') || System.properties.containsKey('tests.cluster')
+def usingMultiNode = project.properties.containsKey('numNodes')
+// Only apply jacoco test coverage if we are running a local single node cluster
+if (!usingRemoteCluster && !usingMultiNode) {
+    apply from: 'build-tools/knnplugin-coverage.gradle'
+}
+
 ext {
     opendistroVersion = '1.6.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
@@ -63,9 +70,6 @@ allprojects {
     }
 }
 
-if (!System.properties.containsKey('tests.rest.cluster') && !System.properties.containsKey('tests.cluster')) {
-    apply from: 'build-tools/knnplugin-coverage.gradle'
-}
 
 jacoco {
     toolVersion = "0.8.3"
@@ -110,28 +114,61 @@ test {
     systemProperty "java.library.path", "$rootDir/buildSrc"
 }
 
+def _numNodes = findProperty('numNodes') as Integer ?: 1
 integTest {
     runner {
         systemProperty 'tests.security.manager', 'false'
         systemProperty 'java.io.tmpdir', es_tmp_dir.absolutePath
+        systemProperty "java.library.path", "$rootDir/buildSrc"
+        // allows integration test classes to access test resource from project root path
+        systemProperty('project.root', project.rootDir.absolutePath)
+
+        doFirst {
+            // Tell the test JVM if the cluster JVM is running under a debugger so that tests can
+            // use longer timeouts for requests.
+            def isDebuggingCluster = getDebug() || System.getProperty("test.debug") != null
+            systemProperty 'cluster.debug', isDebuggingCluster
+            // Set number of nodes system property to be used in tests
+            systemProperty 'cluster.number_of_nodes', "${_numNodes}"
+            // There seems to be an issue when running multi node run or integ tasks with unicast_hosts
+            // not being written, the waitForAllConditions ensures it's written
+            getClusters().forEach { cluster ->
+                cluster.waitForAllConditions()
+            }
+        }
 
         // The -Ddebug.es option makes the cluster debuggable; this makes the tests debuggable
         if (System.getProperty("test.debug") != null) {
             jvmArgs '-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=8000'
         }
-
-        systemProperty "java.library.path", "$rootDir/buildSrc"
-        // allows integration test classes to access test resource from project root path
-        systemProperty('project.root', project.rootDir.absolutePath)
     }
 }
 
 testClusters.integTest {
         testDistribution = "OSS"
+        // Cluster shrink exception thrown if we try to set numberOfNodes to 1, so only apply if > 1
+        if (_numNodes > 1) numberOfNodes = _numNodes
+        // When running integration tests it doesn't forward the --debug-jvm to the cluster anymore
+        // i.e. we have to use a custom property to flag when we want to debug elasticsearch JVM
+        // since we also support multi node integration tests we increase debugPort per node
         if (System.getProperty("cluster.debug") != null) {
-            jvmArgs('-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=5005')
+            def debugPort = 5005
+            nodes.forEach { node ->
+                node.jvmArgs("-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=*:${debugPort}")
+                debugPort += 1
+            }
         }
         systemProperty("java.library.path", "$rootDir/buildSrc")
+}
+
+run {
+    doFirst {
+        // There seems to be an issue when running multi node run or integ tasks with unicast_hosts
+        // not being written, the waitForAllConditions ensures it's written
+        getClusters().forEach { cluster ->
+            cluster.waitForAllConditions()
+        }
+    }
 }
 
 //TODO fix these

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNCircuitBreakerIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNCircuitBreakerIT.java
@@ -41,10 +41,11 @@ public class KNNCircuitBreakerIT extends KNNRestTestCase {
         // Set circuit breaker limit to 1 KB
         updateClusterSettings("knn.memory.circuit_breaker.limit", "1kb");
 
-        // Create Single Shard Index so that all data is hosted on a single node
+        // Create index with 1 primary and numNodes-1 replicas so that the data will be on every node in the cluster
+        int numNodes = Integer.parseInt(System.getProperty("cluster.number_of_nodes"));
         Settings settings = Settings.builder()
                 .put("number_of_shards", 1)
-                .put("number_of_replicas", 2)
+                .put("number_of_replicas", numNodes - 1)
                 .put("index.knn", true)
                 .build();
 


### PR DESCRIPTION
*Issue #, if available:*
#46 

*Description of changes:*
Added logic in build.gradle to run multi-node cluster locally for testing and integration tests. Verified that `./gradlew integTests -PnumNodes=N` for N = 2 and 3 passes. Additionally, verified that a debugger can be attached to each node at the same time.

Along with this, I updated documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
