### PR TITLE
ENH: throws Exception in KNNVectorFieldMapper.parse API when circuit breaker trips

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNVectorFieldMapper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNVectorFieldMapper.java
@@ -243,7 +243,8 @@ public class KNNVectorFieldMapper extends FieldMapper implements ArrayValueMappe
         }
 
         if (KNNSettings.isCircuitBreakerTriggered()) {
-            throw new IllegalStateException("Cannot update KNN vector field when circuit breaker is triggered.");
+            throw new IllegalStateException("Indexing knn vector fields is rejected as circuit breaker triggered." +
+                    " Check _opendistro/_knn/stats for detailed state");
         }
 
         context.path().add(simpleName());

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNVectorFieldMapper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNVectorFieldMapper.java
@@ -242,6 +242,10 @@ public class KNNVectorFieldMapper extends FieldMapper implements ArrayValueMappe
                                                     "update knn.plugin.enabled setting to true");
         }
 
+        if (KNNSettings.isCircuitBreakerTriggered()) {
+            throw new IllegalStateException("Cannot update KNN vector field when circuit breaker is triggered.");
+        }
+
         context.path().add(simpleName());
 
         ArrayList<Float> vector = new ArrayList<>();

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNESIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNESIT.java
@@ -45,8 +45,13 @@ public class KNNESIT extends KNNRestTestCase {
         Float[] vector  = {6.0f, 6.0f};
         ResponseException ex = expectThrows(
                 ResponseException.class, () -> addKnnDoc(INDEX_NAME, "1", FIELD_NAME, vector));
-        assertThat(EntityUtils.toString(ex.getResponse().getEntity()),
-                containsString("Cannot update KNN vector field when circuit breaker is triggered."));
+        String expMessage = "Indexing knn vector fields is rejected as circuit breaker triggered." +
+                " Check _opendistro/_knn/stats for detailed state";
+        assertThat(EntityUtils.toString(ex.getResponse().getEntity()), containsString(expMessage));
+
+        // reset
+        updateClusterSettings("knn.circuit_breaker.triggered", "false");
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, vector);
     }
 
     /**
@@ -75,8 +80,13 @@ public class KNNESIT extends KNNRestTestCase {
         Float[] updatedVector  = {8.0f, 8.0f};
         ResponseException ex = expectThrows(
                 ResponseException.class, () -> updateKnnDoc(INDEX_NAME, "1", FIELD_NAME, vector));
-        assertThat(EntityUtils.toString(ex.getResponse().getEntity()),
-                containsString("Cannot update KNN vector field when circuit breaker is triggered."));
+        String expMessage = "Indexing knn vector fields is rejected as circuit breaker triggered." +
+                " Check _opendistro/_knn/stats for detailed state";
+        assertThat(EntityUtils.toString(ex.getResponse().getEntity()), containsString(expMessage));
+
+        // reset
+        updateClusterSettings("knn.circuit_breaker.triggered", "false");
+        updateKnnDoc(INDEX_NAME, "1", FIELD_NAME, vector);
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*
#96 

*Description of changes:*
- Throws exception before parsing knn vector if the circuit breaker trips 
- Added two integration test cases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
