### PR TITLE
Fix test structure

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/stats/KNNCounter.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/stats/KNNCounter.java
@@ -64,4 +64,11 @@ public enum KNNCounter {
     public void increment() {
         count.getAndIncrement();
     }
+
+    /**
+     * Set the value of a counter
+     */
+    public void set(long value) {
+        count.set(value);
+    }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/KNNRestTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/KNNRestTestCase.java
@@ -13,8 +13,9 @@
  *   permissions and limitations under the License.
  */
 
-package com.amazon.opendistroforelasticsearch.knn.index;
+package com.amazon.opendistroforelasticsearch.knn;
 
+import com.amazon.opendistroforelasticsearch.knn.index.KNNQueryBuilder;
 import com.amazon.opendistroforelasticsearch.knn.plugin.KNNPlugin;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/KNNResult.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/KNNResult.java
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-package com.amazon.opendistroforelasticsearch.knn.index;
+package com.amazon.opendistroforelasticsearch.knn;
 
 public class KNNResult {
     private String docId;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/KNNTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/KNNTestCase.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").
  *   You may not use this file except in compliance with the License.

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/KNNTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/KNNTestCase.java
@@ -13,16 +13,21 @@
  *   permissions and limitations under the License.
  */
 
-package com.amazon.opendistroforelasticsearch.knn.plugin.stats.suppliers;
+package com.amazon.opendistroforelasticsearch.knn;
 
-import com.amazon.opendistroforelasticsearch.knn.KNNTestCase;
 import com.amazon.opendistroforelasticsearch.knn.plugin.stats.KNNCounter;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
 
-public class KNNCounterSupplierTests extends KNNTestCase {
-    public void testNormal() {
-        KNNCounterSupplier knnCounterSupplier = new KNNCounterSupplier(KNNCounter.GRAPH_QUERY_REQUESTS);
-        assertEquals((Long) 0L, knnCounterSupplier.get());
-        KNNCounter.GRAPH_QUERY_REQUESTS.increment();
-        assertEquals((Long) 1L, knnCounterSupplier.get());
+/**
+ * Base class for integration tests for KNN plugin. Contains several methods for testing KNN ES functionality.
+ */
+public class KNNTestCase extends ESTestCase {
+    @Before
+    public void resetCounters() {
+        // Reset all of the counters
+        for (KNNCounter knnCounter : KNNCounter.values()) {
+            knnCounter.set(0L);
+        }
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNCircuitBreakerIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNCircuitBreakerIT.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.knn.index;
 
+import com.amazon.opendistroforelasticsearch.knn.KNNRestTestCase;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.settings.Settings;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNESIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNESIT.java
@@ -15,6 +15,8 @@
 
 package com.amazon.opendistroforelasticsearch.knn.index;
 
+import com.amazon.opendistroforelasticsearch.knn.KNNRestTestCase;
+import com.amazon.opendistroforelasticsearch.knn.KNNResult;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNESSettingsTestIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNESSettingsTestIT.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.knn.index;
 
+import com.amazon.opendistroforelasticsearch.knn.KNNRestTestCase;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.settings.Settings;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNIndexCacheTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNIndexCacheTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
-import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -43,8 +42,9 @@ public class KNNIndexCacheTests extends ESSingleNodeTestCase {
     private final String testIndexName = "test_index";
     private final String testFieldName = "test_field";
 
-    @Before
-    public void setup() {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
         // Reset all of the counters
         for (KNNCounter knnCounter : KNNCounter.values()) {
             knnCounter.set(0L);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNIndexCacheTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNIndexCacheTests.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistroforelasticsearch.knn.index;
 
 import com.amazon.opendistroforelasticsearch.knn.plugin.KNNPlugin;
+import com.amazon.opendistroforelasticsearch.knn.plugin.stats.KNNCounter;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
@@ -28,6 +29,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -40,6 +42,14 @@ import static com.amazon.opendistroforelasticsearch.knn.index.KNNIndexCache.GRAP
 public class KNNIndexCacheTests extends ESSingleNodeTestCase {
     private final String testIndexName = "test_index";
     private final String testFieldName = "test_field";
+
+    @Before
+    public void setup() {
+        // Reset all of the counters
+        for (KNNCounter knnCounter : KNNCounter.values()) {
+            knnCounter.set(0L);
+        }
+    }
 
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNJNITests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNJNITests.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.knn.index;
 
+import com.amazon.opendistroforelasticsearch.knn.KNNTestCase;
 import com.amazon.opendistroforelasticsearch.knn.index.v1736.KNNIndex;
 
 import org.apache.logging.log4j.LogManager;
@@ -22,7 +23,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.FilterDirectory;
-import org.elasticsearch.test.ESTestCase;
 
 import java.nio.file.Paths;
 import java.security.AccessController;
@@ -31,7 +31,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class KNNJNITests extends ESTestCase {
+public class KNNJNITests extends KNNTestCase {
     private static final Logger logger = LogManager.getLogger(KNNJNITests.class);
 
     public void testCreateHnswIndex() throws Exception {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNMapperSearcherIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNMapperSearcherIT.java
@@ -15,6 +15,8 @@
 
 package com.amazon.opendistroforelasticsearch.knn.index;
 
+import com.amazon.opendistroforelasticsearch.knn.KNNRestTestCase;
+import com.amazon.opendistroforelasticsearch.knn.KNNResult;
 import org.apache.http.util.EntityUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNQueryBuilderTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNQueryBuilderTests.java
@@ -15,15 +15,15 @@
 
 package com.amazon.opendistroforelasticsearch.knn.index;
 
+import com.amazon.opendistroforelasticsearch.knn.KNNTestCase;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.test.ESTestCase;
 import org.mockito.Mockito;
 
-public class KNNQueryBuilderTests extends ESTestCase {
+public class KNNQueryBuilderTests extends KNNTestCase {
 
     public void testInvalidK() {
         float[] queryVector = {1.0f, 1.0f};

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNNCodecTestCase.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.knn.index.codec;
 
+import com.amazon.opendistroforelasticsearch.knn.KNNTestCase;
 import com.amazon.opendistroforelasticsearch.knn.index.KNNIndexCache;
 import com.amazon.opendistroforelasticsearch.knn.index.KNNQuery;
 import com.amazon.opendistroforelasticsearch.knn.index.KNNSettings;
@@ -37,7 +38,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.watcher.ResourceWatcherService;
 import org.mockito.Mockito;
 
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.when;
 /**
  * Test used for testing Codecs
  */
-public class  KNNCodecTestCase extends ESTestCase {
+public class  KNNCodecTestCase extends KNNTestCase {
 
     protected void setUpMockClusterService() {
         ClusterService clusterService = mock(ClusterService.class, RETURNS_DEEP_STUBS);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/action/RestKNNStatsHandlerIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/action/RestKNNStatsHandlerIT.java
@@ -15,7 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.knn.plugin.action;
 
-import com.amazon.opendistroforelasticsearch.knn.index.KNNRestTestCase;
+import com.amazon.opendistroforelasticsearch.knn.KNNRestTestCase;
 import com.amazon.opendistroforelasticsearch.knn.index.KNNQueryBuilder;
 import com.amazon.opendistroforelasticsearch.knn.plugin.stats.KNNStats;
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/stats/KNNCounterTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/stats/KNNCounterTests.java
@@ -15,9 +15,9 @@
 
 package com.amazon.opendistroforelasticsearch.knn.plugin.stats;
 
-import org.elasticsearch.test.ESTestCase;
+import com.amazon.opendistroforelasticsearch.knn.KNNTestCase;
 
-public class KNNCounterTests extends ESTestCase {
+public class KNNCounterTests extends KNNTestCase {
     public void testGetName() {
         assertEquals(StatNames.GRAPH_QUERY_ERRORS.getName(), KNNCounter.GRAPH_QUERY_ERRORS.getName());
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/stats/suppliers/KNNCounterSupplierTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/stats/suppliers/KNNCounterSupplierTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.test.ESTestCase;
 
 public class KNNCounterSupplierTests extends ESTestCase {
     public void testNormal() {
+        KNNCounter.GRAPH_QUERY_REQUESTS.set(0L);
         KNNCounterSupplier knnCounterSupplier = new KNNCounterSupplier(KNNCounter.GRAPH_QUERY_REQUESTS);
         assertEquals((Long) 0L, knnCounterSupplier.get());
         KNNCounter.GRAPH_QUERY_REQUESTS.increment();


### PR DESCRIPTION
*Issue #, if available:*
#124 

*Description of changes:*
This PR creates a KNNTestCase from which all unit tests inherit from. This test case adds a method that resets all of the counters before execution. This will make testing independent of gradle test order.

Additionally, KNNRestTestCase and KNNResult were incorrectly placed in the `src/test/java/com/amazon/opendistroforelasticsearch/knn/index`. These two classes are not `index` specific, so I moved them to `src/test/java/com/amazon/opendistroforelasticsearch/knn`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
