### PR TITLE
FIX: copy shared library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,9 +150,9 @@ task buildJniLib(type:Exec) {
 
 task makeJniLib(type: Copy) {
     dependsOn buildJniLib
-    from "$buildDir/jni/release"
+    from "$rootDir/jni/release"
     include "*"
-    into "$buildDir/buildSrc"
+    into "$rootDir/buildSrc"
 }
 
 test {


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Fixes parent directory in makeJniLib gradle task. In the current master running the task leads to

```
Task :makeJniLib NO-SOURCE
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
