### PR TITLE
Cmake fix

### DIFF
--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -19,8 +19,8 @@ project(KNNIndexV1_7_3_6)
 
 # Corner case. For CMake 2.8, there is no option to specify set(CMAKE_CXX_STANDARD 11). Instead, the flag manually needs
 # to be set.
-if (CMAKE_VERSION VERSION_LESS "3.1" AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
+if (CMAKE_VERSION VERSION_LESS "3.1")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 else()
     set(CMAKE_CXX_STANDARD 11)
     set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -17,8 +17,14 @@ cmake_minimum_required(VERSION 2.8)
 
 project(KNNIndexV1_7_3_6)
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
+# Corner case. For CMake 2.8, there is no option to specify set(CMAKE_CXX_STANDARD 11). Instead, the flag manually needs
+# to be set.
+if (CMAKE_VERSION VERSION_LESS "3.1" AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
+else()
+    set(CMAKE_CXX_STANDARD 11)
+    set(CMAKE_CXX_STANDARD_REQUIRED True)
+endif()
 
 # Target Library to be built
 set(KNN_INDEX KNNIndexV1_7_3_6)


### PR DESCRIPTION
*Issue #, if available:*
#137 

*Description of changes:*
Adds compiler flag for c++11 if CMake version is less than 3.1.

Tested on Centos where CMake=2.8 and Ubuntu where CMake=3.5. Both were able to build library successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
