### PR TITLE
Modify artifact release Github action

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -42,9 +42,9 @@ jobs:
             rpm_artifact=`ls packages/*.rpm`
             deb_artifact=`ls packages/*.deb`
 
-            aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-plugins/opendistro-knn/
-            aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-knn/
-            aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-knn/
+            aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-plugins/opendistro-knnlib/
+            aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-knnlib/
+            aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-knnlib/
             aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"
 
       - name: Build and ship plugin artifacts

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -38,11 +38,16 @@ jobs:
             cmake .
             make package
 
-            artifact=`ls release/*.so`
             rpm_artifact=`ls packages/*.rpm`
             deb_artifact=`ls packages/*.deb`
 
-            aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-plugins/opendistro-knnlib/
+            folder_name=`echo $rpm_artifact | sed 's|\(.*\)\..*|\1|'`
+            zip_name=$folder_name".zip"
+            mkdir $folder_name
+            cp release/*.so $folder_name
+            zip $zip_name $folder_name
+
+            aws s3 cp $zip_name s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-plugins/opendistro-knnlib/
             aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-knnlib/
             aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-knnlib/
             aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -47,7 +47,7 @@ jobs:
             cp release/*.so $folder_name
             zip $zip_name $folder_name
 
-            aws s3 cp $zip_name s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-plugins/opendistro-knnlib/
+            aws s3 cp $zip_name s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/opendistro-libs/opendistro-knnlib/ 
             aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-knnlib/
             aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-knnlib/
             aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"


### PR DESCRIPTION
*Issue #, if available:*
#140 

*Description of changes:*
This PR updates the Github action used to publish artifacts to S3. 

Currently, we publish the built binary library to S3, but we have no versioning scheme for it. This PR zips up the binary library into the following format and publishes it to its own S3 bucket. Additionally, the other artifacts are modified to publish to their own buckets as well, as opposed to the plugin's bucket.

Format: `opendistro-knnlib-X.X.X.X-X.X_linux.x86_64.zip`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
