### PR TITLE
added forgotten recursive option to zip

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -38,16 +38,19 @@ jobs:
             cmake .
             make package
 
+            cd packages
+            folder_name=`ls ./*.rpm | sed 's|\(.*\)\..*|\1|'`
+            zip_name=$folder_name".zip"
+            mkdir $folder_name
+            cp ../release/*.so $folder_name
+            zip -r $zip_name $folder_name/*
+            cd ..
+
+            zip_artifact=`ls packages/*.zip`
             rpm_artifact=`ls packages/*.rpm`
             deb_artifact=`ls packages/*.deb`
 
-            folder_name=`echo $rpm_artifact | sed 's|\(.*\)\..*|\1|'`
-            zip_name=$folder_name".zip"
-            mkdir $folder_name
-            cp release/*.so $folder_name
-            zip -r $zip_name $folder_name
-
-            aws s3 cp $zip_name s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/opendistro-libs/opendistro-knnlib/ 
+            aws s3 cp $zip_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/opendistro-libs/opendistro-knnlib/
             aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-knnlib/
             aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-knnlib/
             aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -45,7 +45,7 @@ jobs:
             zip_name=$folder_name".zip"
             mkdir $folder_name
             cp release/*.so $folder_name
-            zip $zip_name $folder_name
+            zip -r $zip_name $folder_name
 
             aws s3 cp $zip_name s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/opendistro-libs/opendistro-knnlib/ 
             aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-knnlib/


### PR DESCRIPTION
*Issue #, if available:*
#140 

*Description of changes:*
PR fixes a bug in github action to produce zip of library. It adds the `-r` flag to zip so that the zip is recursive.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
