### PR TITLE
Reset state for uTs so tests run independently

### DIFF
--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/KNNTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/KNNTestCase.java
@@ -15,19 +15,28 @@
 
 package com.amazon.opendistroforelasticsearch.knn;
 
+import com.amazon.opendistroforelasticsearch.knn.index.KNNIndexCache;
 import com.amazon.opendistroforelasticsearch.knn.plugin.stats.KNNCounter;
 import org.elasticsearch.test.ESTestCase;
-import org.junit.Before;
 
 /**
  * Base class for integration tests for KNN plugin. Contains several methods for testing KNN ES functionality.
  */
 public class KNNTestCase extends ESTestCase {
-    @Before
-    public void resetCounters() {
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        resetState();
+    }
+
+    public static void resetState() {
         // Reset all of the counters
         for (KNNCounter knnCounter : KNNCounter.values()) {
             knnCounter.set(0L);
         }
+
+        // Clean up the cache
+        KNNIndexCache.getInstance().evictAllGraphsFromCache();
+        KNNIndexCache.getInstance().close();
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNIndexCacheTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNIndexCacheTests.java
@@ -15,8 +15,8 @@
 
 package com.amazon.opendistroforelasticsearch.knn.index;
 
+import com.amazon.opendistroforelasticsearch.knn.KNNTestCase;
 import com.amazon.opendistroforelasticsearch.knn.plugin.KNNPlugin;
-import com.amazon.opendistroforelasticsearch.knn.plugin.stats.KNNCounter;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
@@ -43,15 +43,6 @@ public class KNNIndexCacheTests extends ESSingleNodeTestCase {
     private final String testFieldName = "test_field";
 
     @Override
-    public void setUp() throws Exception {
-        // Reset all of the counters
-        for (KNNCounter knnCounter : KNNCounter.values()) {
-            knnCounter.set(0L);
-        }
-        super.setUp();
-    }
-
-    @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
         return Collections.singletonList(KNNPlugin.class);
     }
@@ -64,8 +55,7 @@ public class KNNIndexCacheTests extends ESSingleNodeTestCase {
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        KNNIndexCache.getInstance().evictAllGraphsFromCache();
-        KNNIndexCache.getInstance().close();
+        KNNTestCase.resetState();
     }
 
     public void testGetIndicesCacheStats() throws IOException, InterruptedException, ExecutionException {


### PR DESCRIPTION
*Issue #, if available:*
#158 

*Description of changes:*
Test cases were failing because the state from the KNNIndexCache (singleton) was spilling over from other test cases. This PR prevents this by adding a tearDown method which resets counter, clears out the cache, and closes the cache. 

In order to test, I replicated the failure on an Ubuntu 16 machine. Then, with the change, it passes. Additionally, I tested the change on a Mac. I was not able to reproduce the failure, but, with the fix, `./gradlew build` still passes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
