### PR TITLE
Pass -march=x86-64 to build JNI library

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -35,6 +35,8 @@ jobs:
           CXX: ${{ matrix.compiler }}
         run: |
             cd jni
+            git submodule update --init -- jni/external/nmslib
+            sed -i 's/-march=native/-march=x86-64/g' external/nmslib/similarity_search/CMakeLists.txt
             cmake .
             make package
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ make
 
 The library will be placed in the `jni/release` directory.
 
+## JNI Library Artifacts
+We build and distribute binary library artifacts with Opendistro for Elasticsearch. We build the library binary, RPM and DEB in [this GitHub action](https://github.com/opendistro-for-elasticsearch/k-NN/blob/master/.github/workflows/CD.yml). We use Ubuntu 16.04 with g++ 5.4.0 to build the library. Additionally, in order to provide as much general compatibility as possible, we compile the library without optimized instruction sets enabled. For users that want to get the most out of the library, they should follow [this section](##Build JNI Library RPM/DEB) and build the library from source in their production environment, so that if their environment has optimized instruction sets, they take advantage of them.
+
 ## Build JNI Library RPM/DEB
 
 To build an RPM or DEB of the JNI library, follow these steps:
@@ -44,7 +47,7 @@ make package
 
 The artifacts will be placed in the `jni/packages` directory.
 
-Additionally, we build the RPM and DEB in [this GitHub action](https://github.com/opendistro-for-elasticsearch/k-NN/blob/master/.github/workflows/CD.yml). We use Ubuntu 16.04 with g++ 5.4.0.
+
 
 ## Running Multi-node Cluster Locally
 


### PR DESCRIPTION
*Issue #, if available:*
#163 

*Description of changes:*
This PR changes the way in which we build the JNI library artifacts we release with Opendistro. Previously, we compiled the NMSLIB portion of the library with `-march=native`. The problem with this is that the machine the Github runner used, had optimized instruction sets that are not present on other machines a user might run the plugin on. This would then lead to an unexpected crash.

This PR changes `-march=native` to the more generic `-march=x86-64` compile option, providing more general compatibility for our library. However, this may lead some users to get worse performance than they otherwise expected, because the distributed binary will no longer include optimized instructions. For users to avoid this, they should build the library from source in an environment that mirrors their production environment. This PR adds this suggestion in the README as well.

In order to test, I built the RPM on an Amazon Linux 2 machine on an m5.xlarge EC2 instance and then installed it on an m4.xlarge instance. I was able to confirm that the steps from #163 that led to the crash earlier, did not lead to a crash with this method.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
