### PR TITLE
Add release notes automation

### DIFF
--- a/.github/draft-release-notes-config.yml
+++ b/.github/draft-release-notes-config.yml
@@ -1,12 +1,16 @@
 # The overall template of the release notes
 template: |
-  Compatible with Elasticsearch (**set version here**) and Open Distro for Elasticsearch (**set version here**).
+  Compatible with Elasticsearch (**set version here**).
   $CHANGES
+
 # Setting the formatting and sorting for the release notes body
 name-template: Version (set version here)
-change-template: '- $TITLE (PR #$NUMBER)'
+change-template: '* $TITLE (#$NUMBER)'
 sort-by: merged_at
 sort-direction: ascending
+replacers:
+  - search: '##'
+    replace: '###'
 
 # Organizing the tagged PRs into categories
 categories:

--- a/.github/draft-release-notes-config.yml
+++ b/.github/draft-release-notes-config.yml
@@ -1,0 +1,36 @@
+# The overall template of the release notes
+template: |
+  Compatible with Elasticsearch (**set version here**) and Open Distro for Elasticsearch (**set version here**).
+  $CHANGES
+# Setting the formatting and sorting for the release notes body
+name-template: Version (set version here)
+change-template: '- $TITLE (PR #$NUMBER)'
+sort-by: merged_at
+sort-direction: ascending
+
+# Organizing the tagged PRs into categories
+categories:
+  - title: 'Breaking Changes'
+    labels:
+      - 'Breaking Changes'
+  - title: 'Features'
+    labels:
+      - 'Features'
+  - title: 'Enhancements'
+    labels:
+      - 'Enhancements'
+  - title: 'Bug Fixes'
+    labels:
+      - 'Bug Fixes'
+  - title: 'Infrastructure'
+    labels:
+      - 'Infrastructure'
+  - title: 'Documentation'
+    labels:
+      - 'Documentation'
+  - title: 'Maintenance'
+    labels:
+      - 'Maintenance'
+  - title: 'Refactoring'
+    labels:
+      - 'Refactoring'

--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -1,0 +1,20 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    name: Update draft release notes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update draft release notes
+        uses: release-drafter/release-drafter@v5
+        with:
+          config-name: draft-release-notes-config.yml
+          name: Version (set here)
+          tag: (None)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -404,6 +404,10 @@ GET /_opendistro/_knn/HYMrXXsBSamUkcAjhjeN0w/stats/circuit_breaker_triggered,gra
 }
 ```
 
+## Contributions
+
+We appreciate and encourage contributions from the community. If you experience a bug or have a feature request, please create an issue for it. If you decide to make a contribution, please fill out the Pull Request template with as much detail as possible. Also, when creating a title for your Pull Request, please do not include a prefix such as `Bug Fix:`. Instead, please use the corresponding tag to label the purpose of the Pull Request.
+
 ## REQUEST FOR COMMENT (RFC)
 
 We'd like to get your comments! Please read the plugin RFC [document](https://github.com/opendistro-for-elasticsearch/k-NN/blob/development/RFC.md) and raise an issue to add your comments and questions.


### PR DESCRIPTION
*Issue #, if available:*
#167 

*Description of changes:*
This PR adds automation for the creation of release notes. It adds a Github Action that copies a release notes file based on a template to S3 whenever a commit is added to master. Additionally, this PR adds guidelines on submitting PRs from the community in the README.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
