### PR TITLE
Add Github action to build library artifacts

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -70,7 +70,8 @@ jobs:
       - name: Install dependencies
         run: |
           yum update -y
-          yum install -y cmake rpm-build gcc-c++ make
+          yum install -y cmake rpm-build gcc-c++ make epel-release
+          yum install -y dpkg
 
       - name: Build and ship library artifacts
         env:

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -40,38 +40,43 @@ jobs:
           aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-knn/
           aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"
 
-    library-build-and-ship-zip-and-rpm:
+  library-build-and-ship-zip-and-rpm:
+    name: Build k-NN JNI Library for Zip and RPM
+    runs-on: ubuntu-latest
+    container:
+      image: centos:7
+    strategy:
+      matrix:
+        java: [14]
+        compiler: [g++]
+    steps:
+      - name: Checkout k-NN
+        uses: actions/checkout@v1
+        with:
+          submodules: true
 
-      name: Build k-NN JNI Library for Zip and RPM
-      runs-on: ubuntu-latest
-      container:
-        image: centos:7
-      strategy:
-        matrix:
-          java: [14]
-          compiler: [g++]
-      steps:
-        - name: Checkout k-NN
-        - uses: actions/checkout@v2
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
-        - name: Configure AWS Credentials
-          uses: aws-actions/configure-aws-credentials@v1
-          with:
-            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-            aws-region: us-east-1
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
 
-        - name: Setup Java ${{ matrix.java }}
-          uses: actions/setup-java@v1
-          with:
-            java-version: ${{ matrix.java }}
+      - name: Install dependencies
+        run: |
+          yum update -y
+          yum install -y cmake rpm-build gcc-c++ make
 
-        - name: Build and ship library RPM and ZIP
+      - name: Build and ship library RPM and ZIP
         env:
           CXX: ${{ matrix.compiler }}
         run: |
           cd jni
-          git submodule update --init -- jni/external/nmslib
           sed -i 's/-march=native/-march=x86-64/g' external/nmslib/similarity_search/CMakeLists.txt
           cmake .
           make package
@@ -91,37 +96,43 @@ jobs:
           aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-knnlib/
           aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"
 
-    library-build-and-ship-deb:
-      name: Build k-NN JNI Library for Zip and RPM
-      runs-on: ubuntu-latest
-      container:
-        image: ubuntu:16.04
-      strategy:
-        matrix:
-          java: [14]
-          compiler: [g++-5]
-      steps:
-        - name: Checkout k-NN
-        - uses: actions/checkout@v2
+  library-build-and-ship-deb:
+    name: Build k-NN JNI Library for DEB
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:16.04
+    strategy:
+      matrix:
+        java: [14]
+        compiler: [g++-5]
+    steps:
+      - name: Checkout k-NN
+        uses: actions/checkout@v1
+        with:
+          submodules: true
 
-        - name: Configure AWS Credentials
-          uses: aws-actions/configure-aws-credentials@v1
-          with:
-            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-            aws-region: us-east-1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
-        - name: Setup Java ${{ matrix.java }}
-          uses: actions/setup-java@v1
-          with:
-            java-version: ${{ matrix.java }}
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
 
-        - name: Build and ship library DEB
+      - name: Install dependencies
+        run: |
+          apt-get update -y
+          apt-get install -y cmake rpm ${{ matrix.compiler }}
+
+      - name: Build and ship library DEB
         env:
           CXX: ${{ matrix.compiler }}
         run: |
           cd jni
-          git submodule update --init -- jni/external/nmslib
           sed -i 's/-march=native/-march=x86-64/g' external/nmslib/similarity_search/CMakeLists.txt
           cmake .
           make package

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -71,6 +71,7 @@ jobs:
         run: |
           yum update -y
           yum install -y cmake rpm-build gcc-c++ make epel-release
+          yum repolist
           yum install -y dpkg
 
       - name: Build and ship library artifacts

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         java: [14]
-        compiler: [g++-5]
 
     name: Build and Release k-NN Plugin
     runs-on: ubuntu-latest
@@ -42,10 +41,15 @@ jobs:
           aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"
 
     library-build-and-ship-zip-and-rpm:
+
       name: Build k-NN JNI Library for Zip and RPM
       runs-on: ubuntu-latest
       container:
         image: centos:7
+      strategy:
+        matrix:
+          java: [14]
+          compiler: [g++]
       steps:
         - name: Checkout k-NN
         - uses: actions/checkout@v2
@@ -92,6 +96,10 @@ jobs:
       runs-on: ubuntu-latest
       container:
         image: ubuntu:16.04
+      strategy:
+        matrix:
+          java: [14]
+          compiler: [g++-5]
       steps:
         - name: Checkout k-NN
         - uses: actions/checkout@v2

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -5,12 +5,12 @@ on:
       - v*
 
 jobs:
-  release-plugin-artifacts:
+  plugin-build-and-ship-artifacts:
     strategy:
       matrix:
         java: [14]
 
-    name: Build and Release k-NN Plugin
+    name: Build and release plugin artifacts
     runs-on: ubuntu-latest
     steps:
       - name: Checkout k-NN
@@ -40,8 +40,8 @@ jobs:
           aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-knn/
           aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"
 
-  library-build-and-ship-zip-and-rpm:
-    name: Build k-NN JNI Library for Zip and RPM
+  library-build-and-ship-artifacts:
+    name: Build and release JNI library artifacts
     runs-on: ubuntu-latest
     container:
       image: centos:7
@@ -72,7 +72,7 @@ jobs:
           yum update -y
           yum install -y cmake rpm-build gcc-c++ make
 
-      - name: Build and ship library RPM and ZIP
+      - name: Build and ship library artifacts
         env:
           CXX: ${{ matrix.compiler }}
         run: |
@@ -91,53 +91,9 @@ jobs:
 
           zip_artifact=`ls packages/*.zip`
           rpm_artifact=`ls packages/*.rpm`
+          deb_artifact=`ls packages/*.deb`
 
           aws s3 cp $zip_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/opendistro-libs/opendistro-knnlib/
           aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-knnlib/
-          aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"
-
-  library-build-and-ship-deb:
-    name: Build k-NN JNI Library for DEB
-    runs-on: ubuntu-latest
-    container:
-      image: ubuntu:16.04
-    strategy:
-      matrix:
-        java: [14]
-        compiler: [g++-5]
-    steps:
-      - name: Checkout k-NN
-        uses: actions/checkout@v1
-        with:
-          submodules: true
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
-        with:
-          java-version: ${{ matrix.java }}
-
-      - name: Install dependencies
-        run: |
-          apt-get update -y
-          apt-get install -y cmake rpm ${{ matrix.compiler }}
-
-      - name: Build and ship library DEB
-        env:
-          CXX: ${{ matrix.compiler }}
-        run: |
-          cd jni
-          sed -i 's/-march=native/-march=x86-64/g' external/nmslib/similarity_search/CMakeLists.txt
-          cmake .
-          make package
-
-          deb_artifact=`ls packages/*.deb`
-
           aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-knnlib/
           aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -5,15 +5,14 @@ on:
       - v*
 
 jobs:
-  Build-k-NN:
+  release-plugin-artifacts:
     strategy:
       matrix:
         java: [14]
         compiler: [g++-5]
 
     name: Build and Release k-NN Plugin
-    runs-on: ubuntu-16.04
-
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout k-NN
         uses: actions/checkout@v2
@@ -30,33 +29,6 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
 
-      - name: Build and ship library artifacts
-        env:
-          CXX: ${{ matrix.compiler }}
-        run: |
-            cd jni
-            git submodule update --init -- jni/external/nmslib
-            sed -i 's/-march=native/-march=x86-64/g' external/nmslib/similarity_search/CMakeLists.txt
-            cmake .
-            make package
-
-            cd packages
-            folder_name=`ls ./*.rpm | sed 's|\(.*\)\..*|\1|'`
-            zip_name=$folder_name".zip"
-            mkdir $folder_name
-            cp ../release/*.so $folder_name
-            zip -r $zip_name $folder_name/*
-            cd ..
-
-            zip_artifact=`ls packages/*.zip`
-            rpm_artifact=`ls packages/*.rpm`
-            deb_artifact=`ls packages/*.deb`
-
-            aws s3 cp $zip_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/opendistro-libs/opendistro-knnlib/
-            aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-knnlib/
-            aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-knnlib/
-            aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"
-
       - name: Build and ship plugin artifacts
         run: |
           ./gradlew buildPackages --console=plain -Dbuild.snapshot=false
@@ -67,4 +39,86 @@ jobs:
           aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-plugins/opendistro-knn/
           aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-knn/
           aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-knn/
+          aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"
+
+    library-build-and-ship-zip-and-rpm:
+      name: Build k-NN JNI Library for Zip and RPM
+      runs-on: ubuntu-latest
+      container:
+        image: centos:7
+      steps:
+        - name: Checkout k-NN
+        - uses: actions/checkout@v2
+
+        - name: Configure AWS Credentials
+          uses: aws-actions/configure-aws-credentials@v1
+          with:
+            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            aws-region: us-east-1
+
+        - name: Setup Java ${{ matrix.java }}
+          uses: actions/setup-java@v1
+          with:
+            java-version: ${{ matrix.java }}
+
+        - name: Build and ship library RPM and ZIP
+        env:
+          CXX: ${{ matrix.compiler }}
+        run: |
+          cd jni
+          git submodule update --init -- jni/external/nmslib
+          sed -i 's/-march=native/-march=x86-64/g' external/nmslib/similarity_search/CMakeLists.txt
+          cmake .
+          make package
+
+          cd packages
+          folder_name=`ls ./*.rpm | sed 's|\(.*\)\..*|\1|'`
+          zip_name=$folder_name".zip"
+          mkdir $folder_name
+          cp ../release/*.so $folder_name
+          zip -r $zip_name $folder_name/*
+          cd ..
+
+          zip_artifact=`ls packages/*.zip`
+          rpm_artifact=`ls packages/*.rpm`
+
+          aws s3 cp $zip_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/opendistro-libs/opendistro-knnlib/
+          aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-knnlib/
+          aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"
+
+    library-build-and-ship-deb:
+      name: Build k-NN JNI Library for Zip and RPM
+      runs-on: ubuntu-latest
+      container:
+        image: ubuntu:16.04
+      steps:
+        - name: Checkout k-NN
+        - uses: actions/checkout@v2
+
+        - name: Configure AWS Credentials
+          uses: aws-actions/configure-aws-credentials@v1
+          with:
+            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            aws-region: us-east-1
+
+        - name: Setup Java ${{ matrix.java }}
+          uses: actions/setup-java@v1
+          with:
+            java-version: ${{ matrix.java }}
+
+        - name: Build and ship library DEB
+        env:
+          CXX: ${{ matrix.compiler }}
+        run: |
+          cd jni
+          git submodule update --init -- jni/external/nmslib
+          sed -i 's/-march=native/-march=x86-64/g' external/nmslib/similarity_search/CMakeLists.txt
+          cmake .
+          make package
+
+          deb_artifact=`ls packages/*.deb`
+
+          aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-knnlib/
           aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ make
 The library will be placed in the `jni/release` directory.
 
 ## JNI Library Artifacts
-We build and distribute binary library artifacts with Opendistro for Elasticsearch. We build the library binary, RPM and DEB in [this GitHub action](https://github.com/opendistro-for-elasticsearch/k-NN/blob/master/.github/workflows/CD.yml). We use Ubuntu 16.04 with g++ 5.4.0 to build the DEB and Centos 7 with g++ 4.8.5 to build the RPM and ZIP. Additionally, in order to provide as much general compatibility as possible, we compile the library without optimized instruction sets enabled. For users that want to get the most out of the library, they should follow [this section](##Build JNI Library RPM/DEB) and build the library from source in their production environment, so that if their environment has optimized instruction sets, they take advantage of them.
+We build and distribute binary library artifacts with Opendistro for Elasticsearch. We build the library binary, RPM and DEB in [this GitHub action](https://github.com/opendistro-for-elasticsearch/k-NN/blob/master/.github/workflows/CD.yml). We use Centos 7 with g++ 4.8.5 to build the DEB, RPM and ZIP. Additionally, in order to provide as much general compatibility as possible, we compile the library without optimized instruction sets enabled. For users that want to get the most out of the library, they should follow [this section](##Build JNI Library RPM/DEB) and build the library from source in their production environment, so that if their environment has optimized instruction sets, they take advantage of them.
 
 ## Build JNI Library RPM/DEB
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ make
 The library will be placed in the `jni/release` directory.
 
 ## JNI Library Artifacts
-We build and distribute binary library artifacts with Opendistro for Elasticsearch. We build the library binary, RPM and DEB in [this GitHub action](https://github.com/opendistro-for-elasticsearch/k-NN/blob/master/.github/workflows/CD.yml). We use Ubuntu 16.04 with g++ 5.4.0 to build the library. Additionally, in order to provide as much general compatibility as possible, we compile the library without optimized instruction sets enabled. For users that want to get the most out of the library, they should follow [this section](##Build JNI Library RPM/DEB) and build the library from source in their production environment, so that if their environment has optimized instruction sets, they take advantage of them.
+We build and distribute binary library artifacts with Opendistro for Elasticsearch. We build the library binary, RPM and DEB in [this GitHub action](https://github.com/opendistro-for-elasticsearch/k-NN/blob/master/.github/workflows/CD.yml). We use Ubuntu 16.04 with g++ 5.4.0 to build the DEB and Centos 7 with g++ 4.8.5 to build the RPM and ZIP. Additionally, in order to provide as much general compatibility as possible, we compile the library without optimized instruction sets enabled. For users that want to get the most out of the library, they should follow [this section](##Build JNI Library RPM/DEB) and build the library from source in their production environment, so that if their environment has optimized instruction sets, they take advantage of them.
 
 ## Build JNI Library RPM/DEB
 


### PR DESCRIPTION
*Issue #, if available:*
#169 

*Description of changes:*
This PR changes how the ODFE library artifacts are compiled and shipped. Now, we use a CentOS 7 container to build the RPM and ZIP and an Ubuntu 16.04 container to build the DEB. 

In order to test, I created a subset of the action in my own repository and confirmed the artifacts build for each [container](https://github.com/jmazanec15/k-NN/actions/runs/173087337).

TODO: Test artifacts that are built from containers. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
