### PR TITLE
Update guava version to 29.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,9 @@ task release(type: Copy, group: 'build') {
 //****************************************************************************/
 dependencies {
     compileOnly "org.elasticsearch:elasticsearch:${es_version}"
-    compile group: 'com.google.guava', name: 'guava', version:'15.0'
+    compileOnly group: 'com.google.errorprone', name: 'error_prone_annotations', version:'2.4.0'
+    compile group: 'com.google.guava', name: 'failureaccess', version:'1.0.1'
+    compile group: 'com.google.guava', name: 'guava', version:'29.0-jre'
     testImplementation "org.elasticsearch.test:framework:${es_version}"
 }
 


### PR DESCRIPTION
*Issue #, if available:*
#181 

*Description of changes:*
Updated Guava from 15 to latest (29.0). Along the way, Guava removed error_prone_annotations and failureaccess from it, so we have to add those in order to prevent the build from breaking.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
