### PR TITLE
Fix cluster setting example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ PUT /_cluster/settings
         "knn.plugin.enabled" : true,
         "knn.algo_param.index_thread_qty" : 1,
         "knn.cache.item.expiry.enabled": true,
-        "knn.cache.item.expiry.minutes": 15,
+        "knn.cache.item.expiry.minutes": "15m",
         "knn.memory.circuit_breaker.enabled" : true,
         "knn.memory.circuit_breaker.limit" : "55%",
         "knn.circuit_breaker.unset.percentage": 23


### PR DESCRIPTION
number 15 will throw "reason" : "failed to parse setting [knn.cache.item.expiry.minutes] with value [15] as a time value: unit is missing or unrecognized"
and "15m" works!

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
