### PR TITLE
Add code coverage widget and badges

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -1,9 +1,14 @@
 name: Testing Workflow
-# This workflow is triggered on pull requests to development branch
+# This workflow is triggered on pull requests and pushes to the master and opendistro release branches
 on:
   pull_request:
     branches:
       - master
+      - opendistro-*
+  push:
+    branches:
+      - master
+      - opendistro-*
 jobs:
   build:
     strategy:
@@ -24,3 +29,8 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build with Gradle
         run: ./gradlew build
+      # This step uses the codecov-action Github action: https://github.com/codecov/codecov-action
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Test Workflow](https://github.com/opendistro-for-elasticsearch/k-NN/workflows/Test%20Workflow/badge.svg)](https://github.com/opendistro-for-elasticsearch/k-NN/actions)
+[![Test Workflow](![Testing Workflow](https://github.com/opendistro-for-elasticsearch/k-NN/workflows/Testing%20Workflow/badge.svg))](https://github.com/opendistro-for-elasticsearch/k-NN/actions)
 [![codecov](https://codecov.io/gh/opendistro-for-elasticsearch/k-NN/branch/master/graph/badge.svg)](https://codecov.io/gh/opendistro-for-elasticsearch/k-NN)
 [![Documentation](https://img.shields.io/badge/api-reference-blue.svg)](https://opendistro.github.io/for-elasticsearch-docs/docs/knn/)
 [![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://discuss.opendistrocommunity.dev/c/k-NN/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Test Workflow](https://github.com/opendistro-for-elasticsearch/k-NN/workflows/Test%20Workflow/badge.svg)](https://github.com/opendistro-for-elasticsearch/k-NN/actions)
 [![codecov](https://codecov.io/gh/opendistro-for-elasticsearch/k-NN/branch/master/graph/badge.svg)](https://codecov.io/gh/opendistro-for-elasticsearch/k-NN)
-[![Documentation](https://img.shields.io/badge/api-reference-blue.svg)](https://opendistro.github.io/for-elasticsearch-docs/docs/k-NN/api/)
+[![Documentation](https://img.shields.io/badge/api-reference-blue.svg)](https://opendistro.github.io/for-elasticsearch-docs/docs/knn/)
 [![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://discuss.opendistrocommunity.dev/c/k-NN/)
 ![PRs welcome!](https://img.shields.io/badge/PRs-welcome!-success)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+[![Test Workflow](https://github.com/opendistro-for-elasticsearch/k-NN/workflows/Test%20Workflow/badge.svg)](https://github.com/opendistro-for-elasticsearch/k-NN/actions)
+[![codecov](https://codecov.io/gh/opendistro-for-elasticsearch/k-NN/branch/master/graph/badge.svg)](https://codecov.io/gh/opendistro-for-elasticsearch/k-NN)
+[![Documentation](https://img.shields.io/badge/api-reference-blue.svg)](https://opendistro.github.io/for-elasticsearch-docs/docs/k-NN/api/)
+[![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://discuss.opendistrocommunity.dev/c/k-NN/)
+![PRs welcome!](https://img.shields.io/badge/PRs-welcome!-success)
+
 # Open Distro for Elasticsearch KNN
 
 Open Distro for Elasticsearch enables you to run nearest neighbor search on billions of documents across thousands of dimensions with the same ease as running any regular Elasticsearch query. You can use aggregations and filter clauses to further refine your similarity search operations. K-NN similarity search power use cases such as product recommendations, fraud detection, image and video search, related document search, and more.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Test Workflow](![Testing Workflow](https://github.com/opendistro-for-elasticsearch/k-NN/workflows/Testing%20Workflow/badge.svg))](https://github.com/opendistro-for-elasticsearch/k-NN/actions)
+[![Testing Workflow](https://github.com/opendistro-for-elasticsearch/k-NN/workflows/Testing%20Workflow/badge.svg)](https://github.com/opendistro-for-elasticsearch/k-NN/actions)
 [![codecov](https://codecov.io/gh/opendistro-for-elasticsearch/k-NN/branch/master/graph/badge.svg)](https://codecov.io/gh/opendistro-for-elasticsearch/k-NN)
 [![Documentation](https://img.shields.io/badge/api-reference-blue.svg)](https://opendistro.github.io/for-elasticsearch-docs/docs/knn/)
 [![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://discuss.opendistrocommunity.dev/c/k-NN/)


### PR DESCRIPTION
*Issue #, if available:*
#190 

*Description of changes:*
Added code coverage widget to test workflow.

Additionally, enhanced this test workflow to run on pushes to opendistro release branches as well as master branch.

Lastly, added a few badges to the top of the README

*Related PRs*
https://github.com/opendistro-for-elasticsearch/alerting/pull/223

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
