### PR TITLE
Add AWS CLI in order to ship library artifacts from container

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -70,9 +70,13 @@ jobs:
       - name: Install dependencies
         run: |
           yum update -y
-          yum install -y cmake rpm-build gcc-c++ make epel-release
+          yum install -y cmake rpm-build gcc-c++ make epel-release unzip
           yum repolist
           yum install -y dpkg
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          sudo ./aws/install
+          aws --version
 
       - name: Build and ship library artifacts
         env:


### PR DESCRIPTION
*Issue #, if available:*
#169 

*Description of changes:*
Because we now build and ship library artifacts from Centos container, we need to manually install the AWS CLI in the container. Verified that this installation works on Centos 7.

Related to test Github action failure: https://github.com/opendistro-for-elasticsearch/k-NN/runs/951599939?check_suite_focus=true

Documentation for installing AWS CLI on linux: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
