### PR TITLE
Remove sudo from "./aws install" in library build action

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -75,7 +75,7 @@ jobs:
           yum install -y dpkg
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip awscliv2.zip
-          sudo ./aws/install
+          ./aws/install
           aws --version
 
       - name: Build and ship library artifacts


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Related to this action failure: https://github.com/opendistro-for-elasticsearch/k-NN/runs/1028922087?check_suite_focus=true

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
