### PR TITLE
Fix download link in package description

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -232,7 +232,7 @@ afterEvaluate {
 
         license 'ASL-2.0'
         maintainer 'OpenDistro for Elasticsearch Team <opendistro@amazon.com>'
-        url 'https://opendistro.github.io/elasticsearch/downloads.html'
+        url 'https://opendistro.github.io/for-elasticsearch/downloads.html'
         summary '''
          KNN plugin for OpenDistro for Elasticsearch. 
          Reference documentation can be found at https://opendistro.github.io/for-elasticsearch-docs/.


### PR DESCRIPTION
*Issue #, if available:*
A community user found a bug in the links stated in package descriptions. check the post [here](https://discuss.opendistrocommunity.dev/t/unable-to-setup-apt-repo-for-opendistro-in-our-org/3124)

*Description of changes:*
Fix the download link in package description

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
