### PR TITLE
Fix casting issue with cache expiration

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNIndexCache.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNIndexCache.java
@@ -25,6 +25,7 @@ import com.google.common.cache.RemovalNotification;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.watcher.FileChangesListener;
 import org.elasticsearch.watcher.FileWatcher;
 import org.elasticsearch.watcher.ResourceWatcherService;
@@ -99,7 +100,8 @@ public class KNNIndexCache implements Closeable {
             /**
              * If the hnsw index is not accessed for knn.cache.item.expiry.minutes, it would be garbage collected.
              */
-            long expiryTime = KNNSettings.state().getSettingValue(KNNSettings.KNN_CACHE_ITEM_EXPIRY_TIME_MINUTES);
+            long expiryTime = ((TimeValue) KNNSettings.state()
+                    .getSettingValue(KNNSettings.KNN_CACHE_ITEM_EXPIRY_TIME_MINUTES)).getMinutes();
             cacheBuilder.expireAfterAccess(expiryTime, TimeUnit.MINUTES);
         }
 


### PR DESCRIPTION
*Issue #, if available:*
#203 

*Description of changes:*
Previously, we did not cast `KNNSettings.state().getSettingValue(KNNSettings.KNN_CACHE_ITEM_EXPIRY_TIME_MINUTES))` to `TimeValue` and then get the long value. This was causing the cache to never be rebuilt, causing the circuit breaker limit to exceed 100%. This change fixes that and adds a test to validate it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
