### PR TITLE
Upgrade Elasticsearch to 7.9.1 and ODFE to 1.10.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ if (!usingRemoteCluster) {
 }
 
 ext {
-    opendistroVersion = '1.10.0'
+    opendistroVersion = '1.10.1'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
     projectSubstitutions = [:]
     licenseFile = rootProject.file('LICENSE.TXT')
@@ -66,7 +66,7 @@ ext {
 
 allprojects {
     group = 'com.amazon.opendistroforelasticsearch'
-    version = "${opendistroVersion}.1"
+    version = "${opendistroVersion}.0"
 
     apply from: 'build-tools/repositories.gradle'
     plugins.withId('java') {

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ if (!usingRemoteCluster) {
 }
 
 ext {
-    opendistroVersion = '1.10.1'
+    opendistroVersion = '1.10.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
     projectSubstitutions = [:]
     licenseFile = rootProject.file('LICENSE.TXT')

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
 
 buildscript {
     ext {
-        es_version = System.getProperty("es.version", "7.9.0")
+        es_version = System.getProperty("es.version", "7.9.1")
         es_group = "org.elasticsearch"
         distribution = 'oss-zip'
     }
@@ -66,7 +66,7 @@ ext {
 
 allprojects {
     group = 'com.amazon.opendistroforelasticsearch'
-    version = "${opendistroVersion}.0"
+    version = "${opendistroVersion}.1"
 
     apply from: 'build-tools/repositories.gradle'
     plugins.withId('java') {

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ if (!usingRemoteCluster) {
 }
 
 ext {
-    opendistroVersion = '1.10.0'
+    opendistroVersion = '1.10.1'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
     projectSubstitutions = [:]
     licenseFile = rootProject.file('LICENSE.TXT')

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -72,7 +72,7 @@ install(TARGETS ${KNN_INDEX}
 set(KNN_MAINTAINER "OpenDistro for Elasticsearch Team <opendistro@amazon.com>")
 set(ODFE_DOWNLOAD_URL "https://opendistro.github.io/elasticsearch/downloads")
 set(CPACK_PACKAGE_NAME ${KNN_PACKAGE_NAME})
-set(CPACK_PACKAGE_VERSION 1.10.0.0)
+set(CPACK_PACKAGE_VERSION 1.10.1.0)
 set(CMAKE_INSTALL_PREFIX /usr)
 set(CPACK_GENERATOR "RPM;DEB")
 SET(CPACK_OUTPUT_FILE_PREFIX packages)

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -72,7 +72,7 @@ install(TARGETS ${KNN_INDEX}
 set(KNN_MAINTAINER "OpenDistro for Elasticsearch Team <opendistro@amazon.com>")
 set(ODFE_DOWNLOAD_URL "https://opendistro.github.io/elasticsearch/downloads")
 set(CPACK_PACKAGE_NAME ${KNN_PACKAGE_NAME})
-set(CPACK_PACKAGE_VERSION 1.10.0.1)
+set(CPACK_PACKAGE_VERSION 1.10.1.0)
 set(CMAKE_INSTALL_PREFIX /usr)
 set(CPACK_GENERATOR "RPM;DEB")
 SET(CPACK_OUTPUT_FILE_PREFIX packages)

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -72,7 +72,7 @@ install(TARGETS ${KNN_INDEX}
 set(KNN_MAINTAINER "OpenDistro for Elasticsearch Team <opendistro@amazon.com>")
 set(ODFE_DOWNLOAD_URL "https://opendistro.github.io/elasticsearch/downloads")
 set(CPACK_PACKAGE_NAME ${KNN_PACKAGE_NAME})
-set(CPACK_PACKAGE_VERSION 1.10.0.0)
+set(CPACK_PACKAGE_VERSION 1.10.0.1)
 set(CMAKE_INSTALL_PREFIX /usr)
 set(CPACK_GENERATOR "RPM;DEB")
 SET(CPACK_OUTPUT_FILE_PREFIX packages)

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -72,7 +72,7 @@ install(TARGETS ${KNN_INDEX}
 set(KNN_MAINTAINER "OpenDistro for Elasticsearch Team <opendistro@amazon.com>")
 set(ODFE_DOWNLOAD_URL "https://opendistro.github.io/elasticsearch/downloads")
 set(CPACK_PACKAGE_NAME ${KNN_PACKAGE_NAME})
-set(CPACK_PACKAGE_VERSION 1.10.1.0)
+set(CPACK_PACKAGE_VERSION 1.10.0.0)
 set(CMAKE_INSTALL_PREFIX /usr)
 set(CPACK_GENERATOR "RPM;DEB")
 SET(CPACK_OUTPUT_FILE_PREFIX packages)


### PR DESCRIPTION
*Issue #, if available:*
#216 

*Description of changes:*
Upgrades Elasticsearch version to 7.9.1 and ODFE version to 1.10.1. `./gradlew build` passes. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
