### PR TITLE
[Master]Pre filter support through custom scoring

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/util/KNNConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/util/KNNConstants.java
@@ -21,4 +21,6 @@ public class KNNConstants {
     public static final String HNSW_ALGO_EF_CONSTRUCTION = "efConstruction";
     public static final String HNSW_ALGO_EF_SEARCH = "efSearch";
     public static final String HNSW_ALGO_INDEX_THREAD_QTY = "indexThreadQty";
+    public static final String L2 = "l2";
+    public static final String COSINESIMIL = "cosinesimil";
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/KNNPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/KNNPlugin.java
@@ -198,6 +198,7 @@ public class KNNPlugin extends Plugin implements MapperPlugin, SearchPlugin, Act
      *         "lang": "knn",
      *         "params": {
      *           "field": "my_dense_vector",
+     *           "space": "L2"
      *           "vector": [
      *             1,
      *             1

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringScriptEngine.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringScriptEngine.java
@@ -1,0 +1,40 @@
+package com.amazon.opendistroforelasticsearch.knn.plugin.script;
+
+import org.elasticsearch.script.ScoreScript;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptEngine;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * KNN Custom scoring Engine implementation.
+ */
+public class KNNScoringScriptEngine implements ScriptEngine {
+
+    public static final String NAME = "knn";
+    public static final String SCRIPT_SOURCE = "knn_score";
+
+    @Override
+    public String getType() {
+        return NAME;
+    }
+
+    @Override
+    public <FactoryType> FactoryType compile(String name, String code, ScriptContext<FactoryType> context, Map<String, String> params) {
+        if (ScoreScript.CONTEXT.equals(context) == false) {
+            throw new IllegalArgumentException(getType() + " KNN Vector scoring scripts cannot be used for context [" + context.name + "]");
+        }
+        // we use the script "source" as the script identifier
+        if (!SCRIPT_SOURCE.equals(code)) {
+            throw new IllegalArgumentException("Unknown script name " + code);
+        }
+        ScoreScript.Factory factory = KNNVectorScoreScript.VectorScoreScriptFactory::new;
+        return context.factoryClazz.cast(factory);
+    }
+
+    @Override
+    public Set<ScriptContext<?>> getSupportedContexts() {
+        return null;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringUtil.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringUtil.java
@@ -1,0 +1,76 @@
+package com.amazon.opendistroforelasticsearch.knn.plugin.script;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+
+public class KNNScoringUtil {
+    private static Logger logger = LogManager.getLogger(KNNScoringUtil.class);
+
+    public static float l2Squared(float[] queryVector, float[] inputVector) {
+        float squaredDistance = 0;
+        for (int i = 0; i < inputVector.length; i++) {
+            float diff = queryVector[i]-inputVector[i];
+            squaredDistance += diff * diff;
+        }
+        return squaredDistance;
+    }
+
+    public static float cosinesimilOptimized(float[] queryVector, float[] inputVector, float normQueryVector) {
+        float dotProduct = 0.0f;
+        float normInputVector = 0.0f;
+        for (int i = 0; i < queryVector.length; i++) {
+            dotProduct += queryVector[i] * inputVector[i];
+            normInputVector += inputVector[i] * inputVector[i];
+        }
+        float normalizedProduct = normQueryVector * normInputVector;
+        try {
+            return (float) (dotProduct / (Math.sqrt(normalizedProduct)));
+        } catch(ArithmeticException ex) {
+            logger.debug("Possibly Division by Zero Exception. Returning min score to put this result to end. " +
+                    "Current normalized product " + normalizedProduct);
+            return Float.MIN_VALUE;
+        }
+    }
+
+    public static float cosinesimil(float[] queryVector, float[] inputVector) {
+        float dotProduct = 0.0f;
+        float normQueryVector = 0.0f;
+        float normInputVector = 0.0f;
+        for (int i = 0; i < queryVector.length; i++) {
+            dotProduct += queryVector[i] * inputVector[i];
+            normQueryVector += queryVector[i] * queryVector[i];
+            normInputVector += inputVector[i] * inputVector[i];
+        }
+        float normalizedProduct = normQueryVector * normInputVector;
+        if (normalizedProduct == 0 ) {
+            return Float.MIN_VALUE;
+        }
+        return (float) (dotProduct / (Math.sqrt(normalizedProduct)));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static float[] convertVectorToPrimitive(Object vector) {
+        float[] primitiveVector = null;
+        if(vector != null) {
+            final ArrayList<Double> tmp = (ArrayList<Double>) vector;
+            primitiveVector = new float[tmp.size()];
+            for (int i = 0; i < primitiveVector.length; i++) {
+                primitiveVector[i] = tmp.get(i).floatValue();
+            }
+        }
+        return primitiveVector;
+    }
+
+    public static float getVectorMagnitudeSquared(float[] inputVector) {
+        if (null == inputVector) {
+            throw new IllegalStateException("vector magnitude cannot be evaluated as it is null");
+        }
+        float normInputVector = 0.0f;
+        for (int i = 0; i < inputVector.length; i++) {
+            normInputVector += inputVector[i] * inputVector[i];
+        }
+        return normInputVector;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNVectorScoreScript.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNVectorScoreScript.java
@@ -1,0 +1,166 @@
+package com.amazon.opendistroforelasticsearch.knn.plugin.script;
+
+import com.amazon.opendistroforelasticsearch.knn.index.util.KNNConstants;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.script.ScoreScript;
+import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.UncheckedIOException;
+import java.util.Map;
+
+/**
+ * Vector score script used for adjusting the score based on similarity space
+ * on a per document basis.
+ *
+ */
+public class KNNVectorScoreScript extends ScoreScript {
+
+    private BinaryDocValues binaryDocValuesReader;
+    private final float[] queryVector;
+    private final String similaritySpace;
+    private float queryVectorSquaredMagnitude = -1;
+
+    /**
+     * This function called for each doc in the segment. We evaluate the score of the vector in the doc
+     *
+     * @param explanationHolder A helper to take in an explanation from a script and turn
+     *                          it into an {@link org.apache.lucene.search.Explanation}
+     * @return score of the vector to the query vector
+     */
+    @Override
+    public double execute(ScoreScript.ExplanationHolder explanationHolder) {
+        float score = Float.MIN_VALUE;
+        try {
+            float[] doc_vector;
+            BytesRef bytesref = binaryDocValuesReader.binaryValue();
+            // If there is no vector for the corresponding doc then it should be not considered for nearest
+            // neighbors.
+            if (bytesref == null) {
+                return Float.MIN_VALUE;
+            }
+            try (ByteArrayInputStream byteStream = new ByteArrayInputStream(bytesref.bytes, bytesref.offset, bytesref.length);
+                 ObjectInputStream objectStream = new ObjectInputStream(byteStream)) {
+                doc_vector = (float[]) objectStream.readObject();
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+
+            if(doc_vector.length != queryVector.length) {
+                throw new IllegalStateException("[KNN] query vector and field vector dimensions mismatch. " +
+                        "query vector: " + queryVector.length + ", stored vector: " + doc_vector.length);
+            }
+
+            if (KNNConstants.L2.equalsIgnoreCase(similaritySpace)) {
+                score = KNNScoringUtil.l2Squared(this.queryVector, doc_vector);
+                score = 1/(1 + score);
+            } else if (KNNConstants.COSINESIMIL.equalsIgnoreCase(similaritySpace)) {
+                // Scores cannot be negative so add +1 to the cosine score
+                score = 1 + KNNScoringUtil.cosinesimilOptimized(this.queryVector, doc_vector, this.queryVectorSquaredMagnitude);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return score;
+    }
+
+    @Override
+    public void setDocument(int docId) {
+        try {
+            this.binaryDocValuesReader.advanceExact(docId);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public KNNVectorScoreScript(Map<String, Object> params, String field, float[] queryVector, float queryVectorSquaredMagnitude,
+                                String similaritySpace, SearchLookup lookup, LeafReaderContext leafContext) throws IOException {
+        super(params, lookup, leafContext);
+        // get query vector - convert to primitive
+        final Object vector = params.get("vector");
+        this.similaritySpace = similaritySpace;
+        this.queryVector = queryVector;
+        this.queryVectorSquaredMagnitude = queryVectorSquaredMagnitude;
+        this.binaryDocValuesReader = leafContext.reader().getBinaryDocValues(field);
+        if(this.binaryDocValuesReader == null) {
+            throw new IllegalStateException("Binary Doc values not enabled for the field " + field
+                                                        + " Please ensure the field type is knn_vector in mappings for this field");
+        }
+    }
+
+    public static class VectorScoreScriptFactory implements ScoreScript.LeafFactory {
+        private final Map<String, Object> params;
+        private final SearchLookup lookup;
+        private String similaritySpace;
+        private String field;
+        private final float[] qVector;
+        private float qVectorSquaredMagnitude; // Used for cosine optimization
+
+        public VectorScoreScriptFactory(Map<String, Object> params, SearchLookup lookup) {
+            this.params = params;
+            this.lookup = lookup;
+            validateAndInitParams(params);
+
+            // initialize
+            this.qVector = KNNScoringUtil.convertVectorToPrimitive(params.get("vector"));
+            // Optimization for cosinesimil
+            if (KNNConstants.COSINESIMIL.equalsIgnoreCase(similaritySpace)) {
+                // calculate the magnitude
+                qVectorSquaredMagnitude = KNNScoringUtil.getVectorMagnitudeSquared(qVector);
+            }
+        }
+
+        private void validateAndInitParams(Map<String, Object> params) {
+            // query vector field
+            final Object field = params.get("field");
+            if (field == null)
+                throw new IllegalArgumentException("Missing parameter [field]");
+            this.field = field.toString();
+
+            // query vector
+            final Object qVector = params.get("vector");
+            if (qVector == null) {
+                throw new IllegalArgumentException("Missing query vector parameter [vector]");
+            }
+
+            // validate space
+            final Object space = params.get("space");
+            if (space == null) {
+                throw new IllegalArgumentException("Missing parameter [space]");
+            }
+            this.similaritySpace = (String)space;
+            if (!KNNConstants.COSINESIMIL.equalsIgnoreCase(similaritySpace) && !KNNConstants.L2.equalsIgnoreCase(similaritySpace)) {
+                throw new IllegalArgumentException("Invalid space type. Please refer to the available space types.");
+            }
+        }
+
+        public boolean needs_score() {
+            return false;
+        }
+
+        @Override // called number of segments times
+        public ScoreScript newInstance(LeafReaderContext ctx) throws IOException {
+            if (ctx.reader().getBinaryDocValues(this.field) == null) {
+                /*
+                 * the field and/or term don't exist in this segment,
+                 * so always return 0
+                 */
+                return new ScoreScript(params, lookup, ctx) {
+                    @Override
+                    public double execute(
+                            ExplanationHolder explanation
+                    ) {
+                        return 0.0d;
+                    }
+                };
+            }
+            return new KNNVectorScoreScript(this.params, this.field, this.qVector, this.qVectorSquaredMagnitude,
+                    this.similaritySpace, this.lookup, ctx);
+        }
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/scripts/KNNScoringUtilTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/scripts/KNNScoringUtilTests.java
@@ -1,0 +1,41 @@
+package com.amazon.opendistroforelasticsearch.knn.plugin.scripts;
+
+import com.amazon.opendistroforelasticsearch.knn.KNNTestCase;
+import com.amazon.opendistroforelasticsearch.knn.plugin.script.KNNScoringUtil;
+
+public class KNNScoringUtilTests extends KNNTestCase {
+
+    public void testL2SquaredScoringFunction() {
+        float[] queryVector = {1.0f, 1.0f, 1.0f};
+        float[] inputVector = {4.0f, 4.0f, 4.0f};
+
+        Float distance = KNNScoringUtil.l2Squared(queryVector, inputVector);
+        assertTrue(distance == 27.0f);
+    }
+
+    public void testCosineSimilScoringFunction() {
+        float[] queryVector = {1.0f, 1.0f, 1.0f};
+        float[] inputVector = {4.0f, 4.0f, 4.0f};
+
+        float queryVectorMagnitude = KNNScoringUtil.getVectorMagnitudeSquared(queryVector);
+        float inputVectorMagnitude = KNNScoringUtil.getVectorMagnitudeSquared(inputVector);
+        float dotProduct = 12.0f;
+        float expectedScore = (float) (dotProduct / (Math.sqrt(queryVectorMagnitude * inputVectorMagnitude)));
+
+
+        Float actualScore = KNNScoringUtil.cosinesimil(queryVector, inputVector);
+        assertEquals(expectedScore, actualScore, 0.0001);
+    }
+
+    public void testCosineSimilOptimizedScoringFunction() {
+        float[] queryVector = {1.0f, 1.0f, 1.0f};
+        float[] inputVector = {4.0f, 4.0f, 4.0f};
+        float queryVectorMagnitude = KNNScoringUtil.getVectorMagnitudeSquared(queryVector);
+        float inputVectorMagnitude = KNNScoringUtil.getVectorMagnitudeSquared(inputVector);
+        float dotProduct = 12.0f;
+        float expectedScore = (float) (dotProduct / (Math.sqrt(queryVectorMagnitude * inputVectorMagnitude)));
+
+        Float actualScore = KNNScoringUtil.cosinesimilOptimized(queryVector, inputVector, queryVectorMagnitude);
+        assertEquals(expectedScore, actualScore, 0.0001);
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/scripts/KNNScriptScoringIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/scripts/KNNScriptScoringIT.java
@@ -1,0 +1,108 @@
+package com.amazon.opendistroforelasticsearch.knn.plugin.scripts;
+
+import com.amazon.opendistroforelasticsearch.knn.KNNRestTestCase;
+import com.amazon.opendistroforelasticsearch.knn.KNNResult;
+import com.amazon.opendistroforelasticsearch.knn.index.util.KNNConstants;
+import com.amazon.opendistroforelasticsearch.knn.plugin.script.KNNScoringScriptEngine;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.functionscore.ScriptScoreQueryBuilder;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.script.Script;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class KNNScriptScoringIT extends KNNRestTestCase {
+
+    public void testKNNL2ScriptScore() throws Exception {
+        /*
+         * Create knn index and populate data
+         */
+        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        Float[] f1  = {6.0f, 6.0f};
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, f1);
+
+        Float[] f2  = {2.0f, 2.0f};
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, f2);
+
+        Float[] f3  = {4.0f, 4.0f};
+        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, f3);
+
+        Float[] f4  = {3.0f, 3.0f};
+        addKnnDoc(INDEX_NAME, "4", FIELD_NAME, f4);
+
+
+        /**
+         * Construct Search Request
+         */
+        Request request = new Request(
+                "POST",
+                "/" + INDEX_NAME + "/_search"
+        );
+
+        QueryBuilder qb = new MatchAllQueryBuilder();
+        Map<String, Object> params = new HashMap<>();
+        /*
+         *   params": {
+         *       "field": "my_dense_vector",
+         *       "vector": [2.0, 2.0]
+         *      }
+         *
+         *
+         */
+        float[] queryVector = {1.0f, 1.0f};
+        params.put("field", FIELD_NAME);
+        params.put("vector", queryVector);
+        params.put("space", KNNConstants.L2);
+        Script script = new Script(Script.DEFAULT_SCRIPT_TYPE, KNNScoringScriptEngine.NAME, KNNScoringScriptEngine.SCRIPT_SOURCE, params);
+        ScriptScoreQueryBuilder sc = new ScriptScoreQueryBuilder(qb, script);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("query");
+
+        builder.startObject("script_score");
+        builder.field("query");
+        sc.query().toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.field("script", script);
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+        request = new Request(
+                "POST",
+                "/" + INDEX_NAME + "/_search"
+        );
+
+        request.setJsonEntity(Strings.toString(builder));
+
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK,
+                RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
+        List<String> expectedDocids = Arrays.asList("2", "4", "3", "1");
+
+        List<String> actualDocids = new ArrayList<>();
+        for(KNNResult result : results) {
+            actualDocids.add(result.getDocId());
+        }
+
+        assertEquals(4, results.size());
+
+        // assert document order
+        assertEquals("2", results.get(0).getDocId());
+        assertEquals("4", results.get(1).getDocId());
+        assertEquals("3", results.get(2).getDocId());
+        assertEquals("1", results.get(3).getDocId());
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/scripts/KNNScriptScoringIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/scripts/KNNScriptScoringIT.java
@@ -105,4 +105,81 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         assertEquals("3", results.get(2).getDocId());
         assertEquals("1", results.get(3).getDocId());
     }
+
+    public void testKNNCosineScriptScore() throws Exception {
+        /*
+         * Create knn index and populate data
+         */
+        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        Float[] f1  = {1.0f, -1.0f};
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, f1);
+
+        Float[] f2  = {1.0f, 0.0f};
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, f2);
+
+        Float[] f3  = {1.0f, 1.0f};
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, f3);
+
+
+
+        /**
+         * Construct Search Request
+         */
+        Request request = new Request(
+                "POST",
+                "/" + INDEX_NAME + "/_search"
+        );
+
+        QueryBuilder qb = new MatchAllQueryBuilder();
+        Map<String, Object> params = new HashMap<>();
+        /*
+         *   params": {
+         *       "field": "my_dense_vector",
+         *       "vector": [2.0, 2.0]
+         *      }
+         *
+         *
+         */
+        float[] queryVector = {2.0f, -2.0f};
+        params.put("field", FIELD_NAME);
+        params.put("vector", queryVector);
+        params.put("space", KNNConstants.COSINESIMIL);
+        Script script = new Script(Script.DEFAULT_SCRIPT_TYPE, KNNScoringScriptEngine.NAME, KNNScoringScriptEngine.SCRIPT_SOURCE, params);
+        ScriptScoreQueryBuilder sc = new ScriptScoreQueryBuilder(qb, script);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("query");
+
+        builder.startObject("script_score");
+        builder.field("query");
+        sc.query().toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.field("script", script);
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+        request = new Request(
+                "POST",
+                "/" + INDEX_NAME + "/_search"
+        );
+
+        request.setJsonEntity(Strings.toString(builder));
+
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK,
+                RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
+        List<String> expectedDocids = Arrays.asList("0", "1", "2");
+
+        List<String> actualDocids = new ArrayList<>();
+        for(KNNResult result : results) {
+            actualDocids.add(result.getDocId());
+        }
+
+        assertEquals(3, results.size());
+
+        // assert document order
+        assertEquals("0", results.get(0).getDocId());
+        assertEquals("1", results.get(1).getDocId());
+        assertEquals("2", results.get(2).getDocId());
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/k-NN/issues/50
Parent PR:- https://github.com/opendistro-for-elasticsearch/k-NN/pull/196/ 

- As of today k-NN search queries in combination with filters/boolean queries always work as a post filter search.  k-Nearest Neighbors are evaluated first and then other queries are run on top of the returned k results . When k is small, it is possible we end up less than required k Neighbors after applying the filter.
- This issue becomes more evident especially when k-NN search is combined with filter queries targeting smaller subset of vectors in the large data set.

*Description of changes:*
We define our own custom Script Engine which uses the language name “knn”.  It implements a script class called *VectorScoreScript* which would be called to override each document’s score with the chosen similarity space like Euclidean, Cosine, Dot product etc. Customer could invoke the script using the “script_score” functionality by passing the language name as “knn” and required parameters. 

* The script_score functionality can be incorporated by extending ‘*ScriptPlugin*’. 
* *script_score* is evaluated for the filtered documents at segment level inside a shard. 
* Customers would use *size* attribute to define the ‘k’.
* script would be compiled once on the first request and cached for later 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
