### PR TITLE
Change "space" parameter to "space_type" for custom scoring

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNVectorScoreScript.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNVectorScoreScript.java
@@ -129,9 +129,9 @@ public class KNNVectorScoreScript extends ScoreScript {
             }
 
             // validate space
-            final Object space = params.get("space");
+            final Object space = params.get("space_type");
             if (space == null) {
-                throw new IllegalArgumentException("Missing parameter [space]");
+                throw new IllegalArgumentException("Missing parameter [space_type]");
             }
             this.similaritySpace = (String)space;
             if (!KNNConstants.COSINESIMIL.equalsIgnoreCase(similaritySpace) && !KNNConstants.L2.equalsIgnoreCase(similaritySpace)) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/scripts/KNNScriptScoringIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/scripts/KNNScriptScoringIT.java
@@ -60,7 +60,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         float[] queryVector = {1.0f, 1.0f};
         params.put("field", FIELD_NAME);
         params.put("vector", queryVector);
-        params.put("space", KNNConstants.L2);
+        params.put("space_type", KNNConstants.L2);
         Request request = constructKNNScriptQueryRequest(INDEX_NAME, qb, params, queryVector);
         Response response = client().performRequest(request);
         assertEquals(request.getEndpoint() + ": failed", RestStatus.OK,
@@ -106,7 +106,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
          *   params": {
          *       "field": "my_dense_vector",
          *       "vector": [2.0, 2.0],
-         *       "space": "L2"
+         *       "space_type": "L2"
          *      }
          *
          *
@@ -114,7 +114,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         float[] queryVector = {2.0f, -2.0f};
         params.put("field", FIELD_NAME);
         params.put("vector", queryVector);
-        params.put("space", KNNConstants.COSINESIMIL);
+        params.put("space_type", KNNConstants.COSINESIMIL);
         Request request = constructKNNScriptQueryRequest(INDEX_NAME, qb, params, queryVector);
         Response response = client().performRequest(request);
         assertEquals(request.getEndpoint() + ": failed", RestStatus.OK,
@@ -151,13 +151,13 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
          *   params": {
          *       "field": "my_dense_vector",
          *       "vector": [2.0, 2.0],
-         *       "space": "cosinesimil"
+         *       "space_type": "cosinesimil"
          *      }
          */
         float[] queryVector = {2.0f, -2.0f};
         params.put("field", FIELD_NAME);
         params.put("vector", queryVector);
-        params.put("space", KNNConstants.COSINESIMIL);
+        params.put("space_type", KNNConstants.COSINESIMIL);
         Script script = new Script(Script.DEFAULT_SCRIPT_TYPE, KNNScoringScriptEngine.NAME, "Dummy_source", params);
         ScriptScoreQueryBuilder sc = new ScriptScoreQueryBuilder(qb, script);
 
@@ -196,7 +196,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         float[] queryVector = {2.0f, -2.0f};
         params.put("field", FIELD_NAME);
         params.put("vector", queryVector);
-        params.put("space", INVALID_SPACE);
+        params.put("space_type", INVALID_SPACE);
         Request request = constructKNNScriptQueryRequest(INDEX_NAME, qb, params, queryVector);
         ResponseException ex = expectThrows(ResponseException.class,  () -> client().performRequest(request));
         assertThat(EntityUtils.toString(ex.getResponse().getEntity()),
@@ -216,7 +216,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         Map<String, Object> params = new HashMap<>();
         float[] queryVector = {2.0f, -2.0f};
         params.put("vector", queryVector);
-        params.put("space", KNNConstants.COSINESIMIL);
+        params.put("space_type", KNNConstants.COSINESIMIL);
         Request request = constructKNNScriptQueryRequest(INDEX_NAME, qb, params, queryVector);
         ResponseException ex = expectThrows(ResponseException.class,  () -> client().performRequest(request));
         assertThat(EntityUtils.toString(ex.getResponse().getEntity()),
@@ -232,11 +232,11 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
 
         // Remove space parameter
         params.put("vector", queryVector);
-        params.remove("space");
+        params.remove("space_type");
         Request space_request = constructKNNScriptQueryRequest(INDEX_NAME, qb, params, queryVector);
         ex = expectThrows(ResponseException.class,  () -> client().performRequest(space_request));
         assertThat(EntityUtils.toString(ex.getResponse().getEntity()),
-                containsString("Missing parameter [space]"));
+                containsString("Missing parameter [space_type]"));
     }
 
     public void testUnequalDimensions() throws Exception {
@@ -255,7 +255,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         float[] queryVector = {2.0f, -2.0f, -2.0f};  // query dimension and field dimension mismatch
         params.put("field", FIELD_NAME);
         params.put("vector", queryVector);
-        params.put("space", KNNConstants.COSINESIMIL);
+        params.put("space_type", KNNConstants.COSINESIMIL);
         Request request = constructKNNScriptQueryRequest(INDEX_NAME, qb, params, queryVector);
         ResponseException ex = expectThrows(ResponseException.class,  () -> client().performRequest(request));
         assertThat(EntityUtils.toString(ex.getResponse().getEntity()),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For Approximate k-NN search, we use ["space_type"](https://github.com/opendistro-for-elasticsearch/k-NN/blob/master/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNSettings.java#L69) to specify the space for the index. For custom scoring search, we use the parameter ["space"](https://github.com/opendistro-for-elasticsearch/k-NN/blob/master/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNVectorScoreScript.java#L132). To maintain consistency and prevent confusion, this PR changes the parameter "space" to "space_type" for custom scoring.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
