### PR TITLE
Fix PostingsFormat in KNN Codec

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNN86Codec/KNN86Codec.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNN86Codec/KNN86Codec.java
@@ -82,9 +82,14 @@ public final class KNN86Codec extends Codec {
      * approach of manually overriding.
      */
 
+    PostingsFormat postingsFormat = null;
+    public void setPostingsFormat(PostingsFormat postingsFormat) {
+        this.postingsFormat = postingsFormat;
+    }
+
     @Override
     public PostingsFormat postingsFormat() {
-        return getDelegatee().postingsFormat();
+        return this.postingsFormat;
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNN86Codec/KNN86Codec.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNN86Codec/KNN86Codec.java
@@ -89,6 +89,9 @@ public final class KNN86Codec extends Codec {
 
     @Override
     public PostingsFormat postingsFormat() {
+        if (this.postingsFormat == null) {
+            return getDelegatee().postingsFormat();
+        }
         return this.postingsFormat;
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNN86Codec/KNN86Codec.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNN86Codec/KNN86Codec.java
@@ -44,6 +44,7 @@ public final class KNN86Codec extends Codec {
     private final DocValuesFormat perFieldDocValuesFormat;
     private final CompoundFormat compoundFormat;
     private Codec lucene86Codec;
+    private PostingsFormat postingsFormat = null;
 
     public static final String KNN_86 = "KNN86Codec";
     public static final String LUCENE_86 = "Lucene86"; // Lucene Codec to be used
@@ -82,7 +83,7 @@ public final class KNN86Codec extends Codec {
      * approach of manually overriding.
      */
 
-    PostingsFormat postingsFormat = null;
+
     public void setPostingsFormat(PostingsFormat postingsFormat) {
         this.postingsFormat = postingsFormat;
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/KNNCodecService.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/KNNCodecService.java
@@ -16,7 +16,9 @@
 
 package com.amazon.opendistroforelasticsearch.knn.plugin;
 
+import com.amazon.opendistroforelasticsearch.knn.index.codec.KNN86Codec.KNN86Codec;
 import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.PostingsFormat;
 import org.elasticsearch.index.codec.CodecService;
 
 import static com.amazon.opendistroforelasticsearch.knn.index.codec.KNN86Codec.KNN86Codec.KNN_86;
@@ -35,7 +37,7 @@ class KNNCodecService extends CodecService {
      * return the KNN Codec
      *
      * @param name dummy name
-     * @return KNN80Codec
+     * @return KNN86Codec
      */
     @Override
     public Codec codec(String name) {
@@ -44,5 +46,9 @@ class KNNCodecService extends CodecService {
             throw new IllegalArgumentException("failed to find codec [" + name + "]");
         }
         return codec;
+    }
+
+    public void setPostingsFormat(PostingsFormat postingsFormat) {
+        ((KNN86Codec)codec("")).setPostingsFormat(postingsFormat);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/KNNEngineFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/KNNEngineFactory.java
@@ -16,7 +16,7 @@
 
 package com.amazon.opendistroforelasticsearch.knn.plugin;
 
-import org.elasticsearch.index.codec.CodecService;
+import org.apache.lucene.codecs.Codec;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.engine.EngineFactory;
@@ -27,10 +27,12 @@ import org.elasticsearch.index.engine.InternalEngine;
  */
 class KNNEngineFactory implements EngineFactory {
 
-    private static CodecService codecService = new KNNCodecService();
+    private static KNNCodecService codecService = new KNNCodecService();
 
     @Override
     public Engine newReadWriteEngine(EngineConfig config) {
+        Codec codec =config.getCodec();
+        codecService.setPostingsFormat(codec.postingsFormat());
         EngineConfig engineConfig = new EngineConfig(config.getShardId(), config.getAllocationId(),
                 config.getThreadPool(), config.getIndexSettings(), config.getWarmer(), config.getStore(),
                 config.getMergePolicy(), config.getAnalyzer(), config.getSimilarity(), codecService,

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/KNNEngineFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/KNNEngineFactory.java
@@ -31,8 +31,7 @@ class KNNEngineFactory implements EngineFactory {
 
     @Override
     public Engine newReadWriteEngine(EngineConfig config) {
-        Codec codec =config.getCodec();
-        codecService.setPostingsFormat(codec.postingsFormat());
+        codecService.setPostingsFormat(config.getCodec().postingsFormat());
         EngineConfig engineConfig = new EngineConfig(config.getShardId(), config.getAllocationId(),
                 config.getThreadPool(), config.getIndexSettings(), config.getWarmer(), config.getStore(),
                 config.getMergePolicy(), config.getAnalyzer(), config.getSimilarity(), codecService,

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/KNNEngineFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/KNNEngineFactory.java
@@ -16,7 +16,6 @@
 
 package com.amazon.opendistroforelasticsearch.knn.plugin;
 
-import org.apache.lucene.codecs.Codec;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.engine.EngineFactory;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/k-NN/issues/227

*Description of changes:*
Elasticsearch initiates PostingsFormat based on the MapperService. For KNNCodec, we do not pass MapperService and the PostingsFormat deviates from underlying format for the current Lucene version. Because of this some of the terms that use PostingsFormat could have incompatibility. For example  https://github.com/opendistro-for-elasticsearch/k-NN/issues/227.
Updated KNNCodec to rely on the right PostingsFormat used by underlying Codec of Elasticsearch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
