### PR TITLE
Add existsQuery and fix bug in KNNVectorFieldMapper for ODFE 1.9

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNVectorFieldMapper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNVectorFieldMapper.java
@@ -23,16 +23,14 @@ import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.index.Term;
+import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
@@ -265,7 +263,7 @@ public class KNNVectorFieldMapper extends FieldMapper {
 
         @Override
         public Query existsQuery(QueryShardContext context) {
-            return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
+            return new DocValuesFieldExistsQuery(name());
         }
 
         @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNVectorFieldMapper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNVectorFieldMapper.java
@@ -87,6 +87,7 @@ public class KNNVectorFieldMapper extends FieldMapper {
             FIELD_TYPE.setHasDocValues(true);
             FIELD_TYPE.setDocValuesType(DocValuesType.BINARY);
             FIELD_TYPE.putAttribute(KNN_FIELD, "true"); //This attribute helps to determine knn field type
+            FIELD_TYPE.freeze();
         }
     }
 
@@ -104,12 +105,12 @@ public class KNNVectorFieldMapper extends FieldMapper {
         }
 
         public Builder spaceTypeParam(String key, String paramValue) {
-            Defaults.FIELD_TYPE.putAttribute(key, paramValue.toLowerCase());
+            builder.fieldType.putAttribute(key, paramValue.toLowerCase());
             return builder;
         }
 
         public Builder algoParams(String key, int paramValue) {
-            Defaults.FIELD_TYPE.putAttribute(key, String.valueOf(paramValue));
+            builder.fieldType.putAttribute(key, String.valueOf(paramValue));
             return builder;
         }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/KNNRestTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/KNNRestTestCase.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.junit.AfterClass;
@@ -139,6 +140,32 @@ public class KNNRestTestCase extends ESRestTestCase {
     }
 
     /**
+     * Run exists search
+     */
+    protected Response searchExists(String index, ExistsQueryBuilder existsQueryBuilder, int resultSize) throws
+            IOException {
+
+        Request request = new Request(
+                "POST",
+                "/" + index + "/_search"
+        );
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("query");
+        builder = XContentFactory.jsonBuilder().startObject();
+        builder.field("query", existsQueryBuilder);
+        builder.endObject();
+
+        request.addParameter("size", Integer.toString(resultSize));
+        request.setJsonEntity(Strings.toString(builder));
+
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK,
+                RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        return response;
+    }
+
+    /**
      * Parse the response of KNN search into a List of KNNResults
      */
     protected List<KNNResult> parseSearchResponse(String responseBody, String fieldName) throws IOException {
@@ -207,6 +234,25 @@ public class KNNRestTestCase extends ESRestTestCase {
     }
 
     /**
+     * Utility to create a Knn Index Mapping with multiple k-NN fields
+     */
+    protected String createKnnIndexMapping(List<String> fieldNames, List<Integer> dimensions) throws IOException {
+        assertNotEquals(0, fieldNames.size());
+        assertEquals(fieldNames.size(), dimensions.size());
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject("properties");
+        for (int i = 0; i < fieldNames.size(); i++) {
+            xContentBuilder.startObject(fieldNames.get(i))
+                    .field("type", "knn_vector")
+                    .field("dimension", dimensions.get(i).toString())
+                    .endObject();
+        }
+        xContentBuilder.endObject().endObject();
+
+        return Strings.toString(xContentBuilder);
+    }
+
+    /**
      * Force merge KNN index segments
      */
     protected void forceMergeKnnIndex(String index) throws Exception {
@@ -253,6 +299,27 @@ public class KNNRestTestCase extends ESRestTestCase {
         );
         response = client().performRequest(request);
         assertEquals(request.getEndpoint() + ": failed", RestStatus.OK,
+                RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+    }
+
+    /**
+     * Add a single KNN Doc to an index with multiple fields
+     */
+    protected void addKnnDoc(String index, String docId, List<String> fieldNames, List<Object[]> vectors) throws IOException {
+        Request request = new Request(
+                "POST",
+                "/" + index + "/_doc/" + docId + "?refresh=true"
+        );
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        for (int i = 0; i < fieldNames.size(); i++) {
+            builder.field(fieldNames.get(i), vectors.get(i));
+        }
+        builder.endObject();
+
+        request.setJsonEntity(Strings.toString(builder));
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.CREATED,
                 RestStatus.fromCode(response.getStatusLine().getStatusCode()));
     }
 
@@ -404,6 +471,19 @@ public class KNNRestTestCase extends ESRestTestCase {
         ).collect(Collectors.toList());
 
         return nodeResponses;
+    }
+
+    /**
+     * Get the total hits from search response
+     */
+    @SuppressWarnings("unchecked")
+    protected int parseTotalSearchHits(String searchResponseBody) throws IOException {
+        Map<String, Object> responseMap = (Map<String, Object>)createParser(
+                XContentType.JSON.xContent(),
+                searchResponseBody
+        ).map().get("hits");
+
+        return (int) ((Map<String, Object>)responseMap.get("total")).get("value");
     }
 
     /**

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNVectorFieldMapperTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNVectorFieldMapperTests.java
@@ -26,7 +26,7 @@ import static com.amazon.opendistroforelasticsearch.knn.index.KNNSettings.INDEX_
 import static com.amazon.opendistroforelasticsearch.knn.index.KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_M;
 import static com.amazon.opendistroforelasticsearch.knn.index.KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE;
 
-import static org.elasticsearch.Version.V_7_1_0;
+import static org.elasticsearch.Version.CURRENT;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -39,7 +39,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         Mapper.TypeParser.ParserContext parserContext = mock(Mapper.TypeParser.ParserContext.class);
         MapperService mapperService = mock(MapperService.class);
         IndexSettings indexSettings = new IndexSettings(
-                IndexMetadata.builder(indexName).settings(settings(V_7_1_0))
+                IndexMetadata.builder(indexName).settings(settings(CURRENT))
                         .numberOfShards(1)
                         .numberOfReplicas(0)
                         .version(7)
@@ -48,7 +48,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
                         .aliasesVersion(0)
                         .creationDate(0)
                         .build(),
-                settings(V_7_1_0).build());
+                settings(CURRENT).build());
         when(parserContext.mapperService()).thenReturn(mapperService);
         when(mapperService.getIndexSettings()).thenReturn(indexSettings);
 
@@ -57,14 +57,41 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser();
         typeParser.buildKNNIndexSettings(builder, parserContext);
 
-        assertEquals(KNNVectorFieldMapper.Defaults.FIELD_TYPE.getAttributes().get(KNNConstants.SPACE_TYPE),
-                INDEX_KNN_DEFAULT_SPACE_TYPE);
+        assertEquals(builder.fieldType().getAttributes().get(KNNConstants.SPACE_TYPE), INDEX_KNN_DEFAULT_SPACE_TYPE);
 
-        assertEquals(KNNVectorFieldMapper.Defaults.FIELD_TYPE.getAttributes().get(KNNConstants.HNSW_ALGO_M),
+        assertEquals(builder.fieldType().getAttributes().get(KNNConstants.HNSW_ALGO_M),
                 String.valueOf(INDEX_KNN_DEFAULT_ALGO_PARAM_M));
 
-        assertEquals(KNNVectorFieldMapper.Defaults.FIELD_TYPE.getAttributes().get(
-                KNNConstants.HNSW_ALGO_EF_CONSTRUCTION), String.valueOf(
-                        INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION));
+        assertEquals(builder.fieldType().getAttributes().get(
+                KNNConstants.HNSW_ALGO_EF_CONSTRUCTION), String.valueOf(INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION));
+    }
+
+    public void testBuildKNNIndexSettings_cosineSimilarity() {
+        String indexName = "test-index";
+        String fieldName = "test-fieldname";
+
+        Mapper.TypeParser.ParserContext parserContext = mock(Mapper.TypeParser.ParserContext.class);
+        MapperService mapperService = mock(MapperService.class);
+        IndexSettings indexSettings = new IndexSettings(
+                IndexMetadata.builder(indexName).settings(settings(CURRENT))
+                        .numberOfShards(1)
+                        .numberOfReplicas(0)
+                        .version(7)
+                        .mappingVersion(0)
+                        .settingsVersion(0)
+                        .aliasesVersion(0)
+                        .creationDate(0)
+                        .build(),
+                settings(CURRENT).build());
+        when(parserContext.mapperService()).thenReturn(mapperService);
+        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
+
+        KNNVectorFieldMapper.Builder builder = new KNNVectorFieldMapper.Builder(fieldName);
+
+        KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser();
+        typeParser.buildKNNIndexSettings(builder, parserContext);
+        builder.spaceTypeParam(KNNConstants.SPACE_TYPE, SpaceTypes.cosinesimil.getValue());
+
+        assertEquals(SpaceTypes.cosinesimil.getValue(), builder.fieldType().getAttributes().get(KNNConstants.SPACE_TYPE));
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
#239 

*Description of changes:*
This PR (1) backports the existsQuery type to ODFE 1.9 and fixes the bug related to #239.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
