### PR TITLE
Change path warmup API uses to load graphs into cache

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNIndexShard.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNIndexShard.java
@@ -24,11 +24,14 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.FilterDirectory;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardPath;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -103,9 +106,10 @@ public class KNNIndexShard {
         List<String> hnswFiles = new ArrayList<>();
         for (LeafReaderContext leafReaderContext : indexReader.leaves()) {
             SegmentReader reader = (SegmentReader) FilterLeafReader.unwrap(leafReaderContext.reader());
+            Path shardPath = ((FSDirectory) FilterDirectory.unwrap(reader.directory())).getDirectory();
             hnswFiles.addAll(reader.getSegmentInfo().files().stream()
                     .filter(fileName -> fileName.endsWith(getHNSWFileExtension(reader.getSegmentInfo().info)))
-                    .map(fileName -> shardPath().resolveIndex().resolve(fileName).toString())
+                    .map(fileName -> shardPath.resolve(fileName).toString())
                     .filter(Objects::nonNull)
                     .collect(Collectors.toList()));
         }


### PR DESCRIPTION
*Issue #, if available:*
#255 

*Description of changes:*
Update logic in warmup to get data directory in the same way that KNNWeight.scorer does.

Link to scorer code: https://github.com/opendistro-for-elasticsearch/k-NN/blob/master/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNWeight.java#L73

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
