### PR TITLE
Revert "Change CD workflow to use new staging bucket for artifacts (#238)"

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -28,32 +28,17 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
 
-      - name: Build
+      - name: Build and ship plugin artifacts
         run: |
           ./gradlew buildPackages --console=plain -Dbuild.snapshot=false
+          artifact=`ls build/distributions/*.zip`
+          rpm_artifact=`ls build/distributions/*.rpm`
+          deb_artifact=`ls build/distributions/*.deb`
 
-      - name: Upload to S3
-        shell: bash
-        run: |
-          zip=`ls build/distributions/*.zip`
-          rpm=`ls build/distributions/*.rpm`
-          deb=`ls build/distributions/*.deb`
-
-          # Inject the build number before the suffix
-          zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
-          rpm_outfile=`basename ${rpm%.rpm}-build-${GITHUB_RUN_NUMBER}.rpm`
-          deb_outfile=`basename ${deb%.deb}-build-${GITHUB_RUN_NUMBER}.deb`
-
-          s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshot/elasticsearch-plugins/knn/"
-
-          echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
-          aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}
-
-          echo "Copying ${rpm} to ${s3_prefix}${rpm_outfile}"
-          aws s3 cp --quiet $rpm ${s3_prefix}${rpm_outfile}
-
-          echo "Copying ${deb} to ${s3_prefix}${deb_outfile}"
-          aws s3 cp --quiet $deb ${s3_prefix}${deb_outfile}
+          aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-plugins/opendistro-knn/
+          aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-knn/
+          aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-knn/
+          aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"
 
   library-build-and-ship-artifacts:
     name: Build and release JNI library artifacts
@@ -93,7 +78,7 @@ jobs:
           ./aws/install
           aws --version
 
-      - name: Build
+      - name: Build and ship library artifacts
         env:
           CXX: ${{ matrix.compiler }}
         run: |
@@ -108,26 +93,13 @@ jobs:
           mkdir $folder_name
           cp ../release/*.so $folder_name
           zip -r $zip_name $folder_name/*
+          cd ..
 
-      - name: Upload to S3
-        shell: bash
-        run: |
-          zip=`ls jni/packages/*.zip`
-          rpm=`ls jni/packages/*.rpm`
-          deb=`ls jni/packages/*.deb`
+          zip_artifact=`ls packages/*.zip`
+          rpm_artifact=`ls packages/*.rpm`
+          deb_artifact=`ls packages/*.deb`
 
-          # Inject the build number before the suffix
-          zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
-          rpm_outfile=`basename ${rpm%.rpm}-build-${GITHUB_RUN_NUMBER}.rpm`
-          deb_outfile=`basename ${deb%.deb}-build-${GITHUB_RUN_NUMBER}.deb`
-
-          s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshot/elasticsearch-plugins/knn/"
-
-          echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
-          aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}
-
-          echo "Copying ${rpm} to ${s3_prefix}${rpm_outfile}"
-          aws s3 cp --quiet $rpm ${s3_prefix}${rpm_outfile}
-
-          echo "Copying ${deb} to ${s3_prefix}${deb_outfile}"
-          aws s3 cp --quiet $deb ${s3_prefix}${deb_outfile}
+          aws s3 cp $zip_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/opendistro-libs/opendistro-knnlib/
+          aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-knnlib/
+          aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-knnlib/
+          aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This reverts commit 891df76da35e9a49b02618c643579d2be8d5b6d3. Talked to @gaiksaya , she mentioned we should wait on merging: https://github.com/opendistro-for-elasticsearch/k-NN/pull/238. We are not going for this approach for 1.12 release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
