### PR TITLE
Reformat release notes for 1.12.0.0

### DIFF
--- a/release-notes/opendistro-for-elasticsearch-knn.release-notes-1.12.0.0.md
+++ b/release-notes/opendistro-for-elasticsearch-knn.release-notes-1.12.0.0.md
@@ -5,8 +5,9 @@ Compatible with Elasticsearch 7.10.0
 ### Features
 
 * Support for hamming bit distance in custom scoring ([#267](https://github.com/opendistro-for-elasticsearch/k-NN/pull/267))
+
+### Maintenance
+
 * k-NN plugin support for Elasticsearch version 7.10.0 ([#271](https://github.com/opendistro-for-elasticsearch/k-NN/pull/271))
-
-### Enhancements
-
 * Bump odfe version to 1.12 ([#273](https://github.com/opendistro-for-elasticsearch/k-NN/pull/273))
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Release notes for 1.12.0.0 had 2 PRs with the wrong tag. This PR fixes this for the release notes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
