### PR TITLE
Fix find_path bug in CMakeLists

### DIFF
--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -31,7 +31,7 @@ set(KNN_INDEX KNNIndexV2_0_6)
 set(KNN_PACKAGE_NAME opendistro-knnlib)
 
 # Check if similarity search exists
-find_path(NMS_REPO_DIR NAMES similarity_search PATHS ${CMAKE_CURRENT_SOURCE_DIR}/external/nmslib REQUIRED)
+find_path(NMS_REPO_DIR NAMES similarity_search PATHS ${CMAKE_CURRENT_SOURCE_DIR}/external/nmslib)
 
 # If not, pull the updated submodule
 if (NOT EXISTS ${NMS_REPO_DIR})


### PR DESCRIPTION
*Issue #, if available:*
#279 

*Description of changes:*
This PR fixes a build failure when using CMake >= 3.18. During the build process, we use `find_path` to check if the nmslib submodule has already been pulled. If it has not, we pull it (in line 37). Recently, Ubuntu 18 in Github actions upgraded from Cmake 3.17 to 3.19. 

For some reason, I added the REQUIRED parameter in find_path. This had no effect in Cmake < 3.18. In Cmake >= 3.18, this causes CMake process to fail: https://cmake.org/cmake/help/v3.18/command/find_path.html. So, the fix is to remove REQUIRED parameter.

I verified the change works for CMake 3.19 on Ubuntu 18. I also verified that the fix does not break functionality for 3.17 on my Mac. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
