### PR TITLE
[On Hold] Add bit hamming

### DIFF
--- a/jni/include/com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex.h
+++ b/jni/include/com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex.h
@@ -10,10 +10,26 @@ extern "C" {
 /*
  * Class:     com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex
  * Method:    saveIndex
- * Signature: ([I[[FLjava/lang/String;[Ljava/lang/String;Ljava/lang/String;)V
+ * Signature: ([I[[FLjava/lang/String;[Ljava/lang/String;Ljava/lang/String;Z)V
  */
 JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_saveIndex
-  (JNIEnv *, jclass, jintArray, jobjectArray, jstring, jobjectArray, jstring);
+  (JNIEnv *, jclass, jintArray, jobjectArray, jstring, jobjectArray, jstring, jboolean);
+
+/*
+ * Class:     com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex
+ * Method:    saveIndexI
+ * Signature: ([I[[ILjava/lang/String;[Ljava/lang/String;Ljava/lang/String;Z)V
+ */
+JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_saveIndexI
+  (JNIEnv *, jclass, jintArray, jobjectArray, jstring, jobjectArray, jstring, jboolean);
+
+/*
+ * Class:     com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex
+ * Method:    saveIndexB
+ * Signature: ([I[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;Z)V
+ */
+JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_saveIndexB
+  (JNIEnv *, jclass, jintArray, jobjectArray, jstring, jobjectArray, jstring, jboolean);
 
 /*
  * Class:     com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex
@@ -25,11 +41,35 @@ JNIEXPORT jobjectArray JNICALL Java_com_amazon_opendistroforelasticsearch_knn_in
 
 /*
  * Class:     com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex
+ * Method:    queryIndexI
+ * Signature: (J[II)[Lcom/amazon/opendistroforelasticsearch/knn/index/KNNQueryResult;
+ */
+JNIEXPORT jobjectArray JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_queryIndexI
+  (JNIEnv *, jclass, jlong, jintArray, jint);
+
+/*
+ * Class:     com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex
+ * Method:    queryIndexB
+ * Signature: (JLjava/lang/String;I)[Lcom/amazon/opendistroforelasticsearch/knn/index/KNNQueryResult;
+ */
+JNIEXPORT jobjectArray JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_queryIndexB
+  (JNIEnv *, jclass, jlong, jstring, jint);
+
+/*
+ * Class:     com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex
  * Method:    init
- * Signature: (Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)J
+ * Signature: (Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;Z)J
  */
 JNIEXPORT jlong JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_init
-  (JNIEnv *, jclass, jstring, jobjectArray, jstring);
+  (JNIEnv *, jclass, jstring, jobjectArray, jstring, jboolean);
+
+/*
+ * Class:     com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex
+ * Method:    initI
+ * Signature: (Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;Z)J
+ */
+JNIEXPORT jlong JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_initI
+  (JNIEnv *, jclass, jstring, jobjectArray, jstring, jboolean);
 
 /*
  * Class:     com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex
@@ -37,6 +77,14 @@ JNIEXPORT jlong JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v20
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_gc
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex
+ * Method:    gcI
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_gcI
   (JNIEnv *, jclass, jlong);
 
 /*

--- a/jni/src/com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex.cpp
+++ b/jni/src/com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex.cpp
@@ -23,6 +23,7 @@
 #include "methodfactory.h"
 #include "spacefactory.h"
 #include "space.h"
+#include "unordered_set"
 
 using std::vector;
 
@@ -40,13 +41,18 @@ using similarity::KNNQueue;
 
 extern "C"
 
+const char* datSuffix = ".dat";
+
+std::unordered_set<string> OptimizedSpace {"l2", "cosinesimil"};
+std::unordered_set<string> IntSpace { "bit_hamming" };
+template <typename dist_t>
 struct IndexWrapper {
   IndexWrapper(string spaceType) {
-    space.reset(SpaceFactoryRegistry<float>::Instance().CreateSpace(spaceType, AnyParams()));
-    index.reset(MethodFactoryRegistry<float>::Instance().CreateMethod(false, "hnsw", spaceType, *space, data));
+    space.reset(SpaceFactoryRegistry<dist_t>::Instance().CreateSpace(spaceType, AnyParams()));
+    index.reset(MethodFactoryRegistry<dist_t>::Instance().CreateMethod(false, "hnsw", spaceType, *space, data));
   }
-  std::unique_ptr<Space<float>> space;
-  std::unique_ptr<Index<float>> index;
+  std::unique_ptr<Space<dist_t>> space;
+  std::unique_ptr<Index<dist_t>> index;
   // Index gets constructed with a reference to data (see above) but is otherwise unused
   ObjectVector data;
 };
@@ -85,7 +91,14 @@ void catch_cpp_exception_and_throw_java(JNIEnv* env)
     }
 }
 
-JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_saveIndex(JNIEnv* env, jclass cls, jintArray ids, jobjectArray vectors, jstring indexPath, jobjectArray algoParams, jstring spaceType)
+void freeAndClearObjectVector(ObjectVector& data) {
+    for (auto datum : data) {
+        delete datum;
+    }
+    data.clear();
+}
+
+JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_saveIndex(JNIEnv* env, jclass cls, jintArray ids, jobjectArray vectors, jstring indexPath, jobjectArray algoParams, jstring spaceType, jboolean loadData)
 {
     Space<float>* space = NULL;
     ObjectVector dataset;
@@ -121,6 +134,12 @@ JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206
         index->CreateIndex(AnyParams(paramsList));
         has_exception_in_stack(env);
         const char *indexString = env->GetStringUTFChars(indexPath, 0);
+        // Write object vector binary data for spaces not supporting optimized index
+        if (OptimizedSpace.find(spaceTypeString) == OptimizedSpace.end() || loadData){
+            string indexPathString(indexString);
+            vector<string> dummy;
+            space->WriteObjectVectorBinData(dataset, dummy, indexPathString + datSuffix);
+        }
         index->SaveIndex(indexString);
         env->ReleaseStringUTFChars(indexPath, indexString);
         has_exception_in_stack(env);
@@ -144,10 +163,141 @@ JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206
     }
 }
 
+JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_saveIndexI(JNIEnv* env, jclass cls, jintArray ids, jobjectArray vectors, jstring indexPath, jobjectArray algoParams, jstring spaceType, jboolean loadData)
+{
+    Space<int>* space = NULL;
+    ObjectVector dataset;
+    Index<int>* index = NULL;
+    int* object_ids = NULL;
+
+    try {
+        const char *spaceTypeCStr = env->GetStringUTFChars(spaceType, 0);
+        string spaceTypeString(spaceTypeCStr);
+        env->ReleaseStringUTFChars(spaceType, spaceTypeCStr);
+        has_exception_in_stack(env);
+        space = SpaceFactoryRegistry<int>::Instance().CreateSpace(spaceTypeString, AnyParams());
+        object_ids = env->GetIntArrayElements(ids, 0);
+        for (int i = 0; i < env->GetArrayLength(vectors); i++) {
+            jintArray vectorArray = (jintArray)env->GetObjectArrayElement(vectors, i);
+            int* vector = env->GetIntArrayElements(vectorArray, 0);
+            dataset.push_back(new Object(object_ids[i], -1, env->GetArrayLength(vectorArray)*sizeof(int), vector));
+            env->ReleaseIntArrayElements(vectorArray, vector, 0);
+        }
+        // free up memory
+        env->ReleaseIntArrayElements(ids, object_ids, 0);
+        index = MethodFactoryRegistry<int>::Instance().CreateMethod(false, "hnsw", spaceTypeString, *space, dataset);
+
+        int paramsCount = env->GetArrayLength(algoParams);
+        vector<string> paramsList;
+        for (int i=0; i<paramsCount; i++) {
+            jstring param = (jstring) (env->GetObjectArrayElement(algoParams, i));
+            const char *rawString = env->GetStringUTFChars(param, 0);
+            paramsList.push_back(rawString);
+            env->ReleaseStringUTFChars(param, rawString);
+        }
+
+        index->CreateIndex(AnyParams(paramsList));
+        has_exception_in_stack(env);
+        const char *indexString = env->GetStringUTFChars(indexPath, 0);
+        // Write object vector binary data for spaces not supporting optimized index
+        if (OptimizedSpace.find(spaceTypeString) == OptimizedSpace.end() || loadData){
+            string indexPathString(indexString);
+            vector<string> dummy;
+            space->WriteObjectVectorBinData(dataset, dummy, indexPathString + datSuffix);
+        }
+        index->SaveIndex(indexString);
+        env->ReleaseStringUTFChars(indexPath, indexString);
+        has_exception_in_stack(env);
+
+        // Free each object in the dataset. No need to clear the vector because it goes out of scope
+        // immediately
+        for (auto it = dataset.begin(); it != dataset.end(); it++) {
+             delete *it;
+        }
+        delete index;
+        delete space;
+    }
+    catch (...) {
+        if (object_ids) { env->ReleaseIntArrayElements(ids, object_ids, 0); }
+        for (auto it = dataset.begin(); it != dataset.end(); it++) {
+             delete *it;
+        }
+        if (index) { delete index; }
+        if (space) { delete space; }
+        catch_cpp_exception_and_throw_java(env);
+    }
+}
+JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_saveIndexB(JNIEnv* env, jclass cls, jintArray ids, jobjectArray vectors, jstring indexPath, jobjectArray algoParams, jstring spaceType, jboolean loadData)
+{
+    Space<int>* space = NULL;
+    ObjectVector dataset;
+    Index<int>* index = NULL;
+    int* object_ids = NULL;
+
+    try {
+        const char *spaceTypeCStr = env->GetStringUTFChars(spaceType, 0);
+        string spaceTypeString(spaceTypeCStr);
+        env->ReleaseStringUTFChars(spaceType, spaceTypeCStr);
+        has_exception_in_stack(env);
+        space = SpaceFactoryRegistry<int>::Instance().CreateSpace(spaceTypeString, AnyParams());
+        object_ids = env->GetIntArrayElements(ids, 0);
+        for (int i = 0; i < env->GetArrayLength(vectors); i++) {
+            jstring vectorArray = (jstring)env->GetObjectArrayElement(vectors, i);
+            const char *vector = env->GetStringUTFChars(vectorArray, 0);
+            string vectrStr(vector);
+            dataset.push_back(
+                space->CreateObjFromStr(object_ids[i], -1, vectrStr, NULL).release()
+            );
+            env->ReleaseStringUTFChars(vectorArray, vector);
+        }
+        // free up memory
+        env->ReleaseIntArrayElements(ids, object_ids, 0);
+        index = MethodFactoryRegistry<int>::Instance().CreateMethod(false, "hnsw", spaceTypeString, *space, dataset);
+
+        int paramsCount = env->GetArrayLength(algoParams);
+        vector<string> paramsList;
+        for (int i=0; i<paramsCount; i++) {
+            jstring param = (jstring) (env->GetObjectArrayElement(algoParams, i));
+            const char *rawString = env->GetStringUTFChars(param, 0);
+            paramsList.push_back(rawString);
+            env->ReleaseStringUTFChars(param, rawString);
+        }
+
+        index->CreateIndex(AnyParams(paramsList));
+        has_exception_in_stack(env);
+        const char *indexString = env->GetStringUTFChars(indexPath, 0);
+        // Write object vector binary data for spaces not supporting optimized index
+        if (OptimizedSpace.find(spaceTypeString) == OptimizedSpace.end() || loadData){
+            string indexPathString(indexString);
+            vector<string> dummy;
+            space->WriteObjectVectorBinData(dataset, dummy, indexPathString + datSuffix);
+        }
+        index->SaveIndex(indexString);
+        env->ReleaseStringUTFChars(indexPath, indexString);
+        has_exception_in_stack(env);
+
+        // Free each object in the dataset. No need to clear the vector because it goes out of scope
+        // immediately
+        for (auto it = dataset.begin(); it != dataset.end(); it++) {
+             delete *it;
+        }
+        delete index;
+        delete space;
+    }
+    catch (...) {
+        if (object_ids) { env->ReleaseIntArrayElements(ids, object_ids, 0); }
+        for (auto it = dataset.begin(); it != dataset.end(); it++) {
+             delete *it;
+        }
+        if (index) { delete index; }
+        if (space) { delete space; }
+        catch_cpp_exception_and_throw_java(env);
+    }
+}
 JNIEXPORT jobjectArray JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_queryIndex(JNIEnv* env, jclass cls, jlong indexPointer, jfloatArray queryVector, jint k)
 {
     try {
-        IndexWrapper *indexWrapper = reinterpret_cast<IndexWrapper*>(indexPointer);
+        IndexWrapper<float> *indexWrapper = reinterpret_cast<IndexWrapper<float>*>(indexPointer);
 
         float* rawQueryvector = env->GetFloatArrayElements(queryVector, 0);
         std::unique_ptr<const Object> queryObject(new Object(-1, -1, env->GetArrayLength(queryVector)*sizeof(float), rawQueryvector));
@@ -174,10 +324,72 @@ JNIEXPORT jobjectArray JNICALL Java_com_amazon_opendistroforelasticsearch_knn_in
     }
     return NULL;
 }
-
-JNIEXPORT jlong JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_init(JNIEnv* env, jclass cls,  jstring indexPath, jobjectArray algoParams, jstring spaceType)
+JNIEXPORT jobjectArray JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_queryIndexI(JNIEnv* env, jclass cls, jlong indexPointer, jintArray queryVector, jint k)
 {
-    IndexWrapper *indexWrapper = NULL;
+    try {
+        IndexWrapper<int> *indexWrapper = reinterpret_cast<IndexWrapper<int>*>(indexPointer);
+
+        int* rawQueryvector = env->GetIntArrayElements(queryVector, 0);
+        std::unique_ptr<const Object> queryObject(new Object(-1, -1, env->GetArrayLength(queryVector)*sizeof(int), rawQueryvector));
+        env->ReleaseIntArrayElements(queryVector, rawQueryvector, 0);
+        has_exception_in_stack(env);
+
+        KNNQuery<int> knnQuery(*(indexWrapper->space), queryObject.get(), k);
+        indexWrapper->index->Search(&knnQuery);
+        std::unique_ptr<KNNQueue<int>> result(knnQuery.Result()->Clone());
+        has_exception_in_stack(env);
+        int resultSize = result->Size();
+        jclass resultClass = env->FindClass("com/amazon/opendistroforelasticsearch/knn/index/KNNQueryResult");
+        jmethodID allArgs = env->GetMethodID(resultClass, "<init>", "(IF)V");
+        jobjectArray results = env->NewObjectArray(resultSize, resultClass, NULL);
+        for (int i = 0; i < resultSize; i++) {
+            float distance = result->TopDistance();
+            long id = result->Pop()->id();
+            env->SetObjectArrayElement(results, i, env->NewObject(resultClass, allArgs, id, distance));
+        }
+        has_exception_in_stack(env);
+        return results;
+    } catch(...) {
+        catch_cpp_exception_and_throw_java(env);
+    }
+    return NULL;
+}
+JNIEXPORT jobjectArray JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_queryIndexB(JNIEnv* env, jclass cls, jlong indexPointer, jstring queryVector, jint k)
+{
+    try {
+        IndexWrapper<int> *indexWrapper = reinterpret_cast<IndexWrapper<int>*>(indexPointer);
+
+        const char *rawQueryvector = env->GetStringUTFChars(queryVector, 0);
+        string rawQueryvectorStr(rawQueryvector);
+        env->ReleaseStringUTFChars(queryVector, rawQueryvector);
+        std::unique_ptr<const Object> queryObject(
+            indexWrapper->space->CreateObjFromStr(-1, -1, rawQueryvectorStr, NULL).release()
+        );
+        has_exception_in_stack(env);
+
+        KNNQuery<int> knnQuery(*(indexWrapper->space), queryObject.get(), k);
+        indexWrapper->index->Search(&knnQuery);
+        std::unique_ptr<KNNQueue<int>> result(knnQuery.Result()->Clone());
+        has_exception_in_stack(env);
+        int resultSize = result->Size();
+        jclass resultClass = env->FindClass("com/amazon/opendistroforelasticsearch/knn/index/KNNQueryResult");
+        jmethodID allArgs = env->GetMethodID(resultClass, "<init>", "(IF)V");
+        jobjectArray results = env->NewObjectArray(resultSize, resultClass, NULL);
+        for (int i = 0; i < resultSize; i++) {
+            float distance = result->TopDistance();
+            long id = result->Pop()->id();
+            env->SetObjectArrayElement(results, i, env->NewObject(resultClass, allArgs, id, distance));
+        }
+        has_exception_in_stack(env);
+        return results;
+    } catch(...) {
+        catch_cpp_exception_and_throw_java(env);
+    }
+    return NULL;
+}
+JNIEXPORT jlong JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_init(JNIEnv* env, jclass cls,  jstring indexPath, jobjectArray algoParams, jstring spaceType, jboolean loadData)
+{
+    IndexWrapper<float> *indexWrapper = NULL;
     try {
         const char *indexPathCStr = env->GetStringUTFChars(indexPath, 0);
         string indexPathString(indexPathCStr);
@@ -189,7 +401,59 @@ JNIEXPORT jlong JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v20
         string spaceTypeString(spaceTypeCStr);
         env->ReleaseStringUTFChars(spaceType, spaceTypeCStr);
         has_exception_in_stack(env);
-        IndexWrapper *indexWrapper = new IndexWrapper(spaceTypeString);
+        IndexWrapper<float> *indexWrapper = new IndexWrapper<float>(spaceTypeString);
+        // Read object vector binary data for spaces not supporting optimized index
+        if (OptimizedSpace.find(spaceTypeString) == OptimizedSpace.end() || loadData){
+            vector<string> dummy;
+            freeAndClearObjectVector(indexWrapper->data);
+            indexWrapper->space->ReadObjectVectorFromBinData(indexWrapper->data, dummy, indexPathString + datSuffix);
+        }
+        indexWrapper->index->LoadIndex(indexPathString);
+
+        // Parse and set query params
+        int paramsCount = env->GetArrayLength(algoParams);
+        vector<string> paramsList;
+        for (int i=0; i<paramsCount; i++) {
+            jstring param = (jstring) (env->GetObjectArrayElement(algoParams, i));
+            const char *rawString = env->GetStringUTFChars(param, 0);
+            paramsList.push_back(rawString);
+            env->ReleaseStringUTFChars(param, rawString);
+        }
+        indexWrapper->index->SetQueryTimeParams(AnyParams(paramsList));
+        has_exception_in_stack(env);
+
+        return (jlong) indexWrapper;
+    }
+    // nmslib seems to throw std::runtime_error if the index cannot be read (which
+    // is the only known failure mode for init()).
+    catch (...) {
+        if (indexWrapper) delete indexWrapper;
+        catch_cpp_exception_and_throw_java(env);
+    }
+    return NULL;
+}
+
+JNIEXPORT jlong JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_initI(JNIEnv* env, jclass cls,  jstring indexPath, jobjectArray algoParams, jstring spaceType, jboolean loadData)
+{
+    IndexWrapper<int> *indexWrapper = NULL;
+    try {
+        const char *indexPathCStr = env->GetStringUTFChars(indexPath, 0);
+        string indexPathString(indexPathCStr);
+        env->ReleaseStringUTFChars(indexPath, indexPathCStr);
+        has_exception_in_stack(env);
+
+        // Load index from file (may throw)
+        const char *spaceTypeCStr = env->GetStringUTFChars(spaceType, 0);
+        string spaceTypeString(spaceTypeCStr);
+        env->ReleaseStringUTFChars(spaceType, spaceTypeCStr);
+        has_exception_in_stack(env);
+        IndexWrapper<int> *indexWrapper = new IndexWrapper<int>(spaceTypeString);
+        // Read object vector binary data for spaces not supporting optimized index
+        if (OptimizedSpace.find(spaceTypeString) == OptimizedSpace.end() || loadData){
+            vector<string> dummy;
+            freeAndClearObjectVector(indexWrapper->data);
+            indexWrapper->space->ReadObjectVectorFromBinData(indexWrapper->data, dummy, indexPathString + datSuffix);
+        }
         indexWrapper->index->LoadIndex(indexPathString);
 
         // Parse and set query params
@@ -218,7 +482,7 @@ JNIEXPORT jlong JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v20
 JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_gc(JNIEnv* env, jclass cls,  jlong indexPointer)
 {
     try {
-        IndexWrapper *indexWrapper = reinterpret_cast<IndexWrapper*>(indexPointer);
+        IndexWrapper<float> *indexWrapper = reinterpret_cast<IndexWrapper<float>*>(indexPointer);
         has_exception_in_stack(env);
         delete indexWrapper;
         has_exception_in_stack(env);
@@ -227,7 +491,18 @@ JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206
         catch_cpp_exception_and_throw_java(env);
     }
 }
-
+JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_gcI(JNIEnv* env, jclass cls,  jlong indexPointer)
+{
+    try {
+        IndexWrapper<int> *indexWrapper = reinterpret_cast<IndexWrapper<int>*>(indexPointer);
+        has_exception_in_stack(env);
+        delete indexWrapper;
+        has_exception_in_stack(env);
+    }
+    catch (...) {
+        catch_cpp_exception_and_throw_java(env);
+    }
+}
 JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex_initLibrary(JNIEnv *, jclass)
 {
     initLibrary();

--- a/jni/src/com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex.cpp
+++ b/jni/src/com_amazon_opendistroforelasticsearch_knn_index_v206_KNNIndex.cpp
@@ -51,6 +51,13 @@ struct IndexWrapper {
     space.reset(SpaceFactoryRegistry<dist_t>::Instance().CreateSpace(spaceType, AnyParams()));
     index.reset(MethodFactoryRegistry<dist_t>::Instance().CreateMethod(false, "hnsw", spaceType, *space, data));
   }
+  virtual ~IndexWrapper() {
+    for(auto it = data.begin(); it != data.end(); ++it) {
+        if(*it != nullptr) {
+            delete *it;
+        }
+    }
+  }
   std::unique_ptr<Space<dist_t>> space;
   std::unique_ptr<Index<dist_t>> index;
   // Index gets constructed with a reference to data (see above) but is otherwise unused

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNQuery.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNQuery.java
@@ -46,17 +46,25 @@ public class KNNQuery extends Query {
     public float[] getQueryVector() {
         return this.queryVector;
     }
-    public String getQueryVectorStr() {
 
-        //[1,0,1,0,1] --> "1 0 1 0 1"
-        char[] charArray = new char[this.queryVector.length*2];
-        for (int bit = 0; bit < this.queryVector.length; ++bit) {
-            int oneBit = ((int)(this.queryVector[bit]))%2;
-            charArray[bit*2] = (char) ('0' + oneBit);
-            charArray[bit*2+1] = ' ';
+    public int[] getQueryVectorInt() {
+        int[] queryVectorI = new int[queryVector.length];
+        for(int i = 0; i < queryVector.length; ++i) {
+            queryVectorI[i] = (int)queryVector[i];
         }
-        return String.valueOf(charArray);
+        return queryVectorI;
     }
+//    public String getQueryVectorStr() {
+//
+//        //[1,0,1,0,1] --> "1 0 1 0 1"
+//        char[] charArray = new char[this.queryVector.length*2];
+//        for (int bit = 0; bit < this.queryVector.length; ++bit) {
+//            int oneBit = ((int)(this.queryVector[bit]))%2;
+//            charArray[bit*2] = (char) ('0' + oneBit);
+//            charArray[bit*2+1] = ' ';
+//        }
+//        return String.valueOf(charArray);
+//    }
 
     public int getK() {
         return this.k;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNQuery.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNQuery.java
@@ -46,6 +46,17 @@ public class KNNQuery extends Query {
     public float[] getQueryVector() {
         return this.queryVector;
     }
+    public String getQueryVectorStr() {
+
+        //[1,0,1,0,1] --> "1 0 1 0 1"
+        char[] charArray = new char[this.queryVector.length*2];
+        for (int bit = 0; bit < this.queryVector.length; ++bit) {
+            int oneBit = ((int)(this.queryVector[bit]))%2;
+            charArray[bit*2] = (char) ('0' + oneBit);
+            charArray[bit*2+1] = ' ';
+        }
+        return String.valueOf(charArray);
+    }
 
     public int getK() {
         return this.k;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNWeight.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNWeight.java
@@ -99,11 +99,11 @@ public class KNNWeight extends Weight {
             Path indexPath = PathUtils.get(directory, hnswFiles.get(0));
             final KNNIndex index = knnIndexCache.getIndex(indexPath.toString(), knnQuery.getIndexName());
             final KNNQueryResult[] results;
-            boolean stringSapces = SpaceTypes.getStringSpaces().contains(index.getSpaceType());
+            boolean intSpaces = SpaceTypes.getIntSpaces().contains(index.getSpaceType());
 
-            if (stringSapces) {
+            if (intSpaces) {
                 results = index.queryIndex(
-                        knnQuery.getQueryVectorStr(),
+                        knnQuery.getQueryVectorInt(),
                         knnQuery.getK()
                 );
             } else {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNWeight.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNWeight.java
@@ -100,6 +100,7 @@ public class KNNWeight extends Weight {
             final KNNIndex index = knnIndexCache.getIndex(indexPath.toString(), knnQuery.getIndexName());
             final KNNQueryResult[] results;
             boolean stringSapces = SpaceTypes.getStringSpaces().contains(index.getSpaceType());
+
             if (stringSapces) {
                 results = index.queryIndex(
                         knnQuery.getQueryVectorStr(),

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNWeight.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNWeight.java
@@ -98,10 +98,19 @@ public class KNNWeight extends Weight {
 
             Path indexPath = PathUtils.get(directory, hnswFiles.get(0));
             final KNNIndex index = knnIndexCache.getIndex(indexPath.toString(), knnQuery.getIndexName());
-            final KNNQueryResult[] results = index.queryIndex(
-                    knnQuery.getQueryVector(),
-                    knnQuery.getK()
-            );
+            final KNNQueryResult[] results;
+            boolean stringSapces = SpaceTypes.getStringSpaces().contains(index.getSpaceType());
+            if (stringSapces) {
+                results = index.queryIndex(
+                        knnQuery.getQueryVectorStr(),
+                        knnQuery.getK()
+                );
+            } else {
+                results = index.queryIndex(
+                        knnQuery.getQueryVector(),
+                        knnQuery.getK()
+                );
+            }
 
             /**
              * Scores represent the distance of the documents with respect to given query vector.
@@ -110,7 +119,7 @@ public class KNNWeight extends Weight {
              * neighbors we are inverting the scores.
              */
             Map<Integer, Float> scores = Arrays.stream(results).collect(
-                    Collectors.toMap(result -> result.getId(), result -> 1/(1 + result.getScore())));
+                    Collectors.toMap(result -> result.getId(), result -> scoreFunc(result.getScore())));
             int maxDoc = Collections.max(scores.keySet()) + 1;
             DocIdSetBuilder docIdSetBuilder = new DocIdSetBuilder(maxDoc);
             DocIdSetBuilder.BulkAdder setAdder = docIdSetBuilder.grow(maxDoc);
@@ -122,6 +131,14 @@ public class KNNWeight extends Weight {
     @Override
     public boolean isCacheable(LeafReaderContext context) {
         return true;
+    }
+
+    public static float scoreFunc(float score) {
+        if (score >= 0) {
+            return 1 / (1 + score);
+        } else {
+            return 2 + 1 / (score - 1);
+        }
     }
 }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/SpaceTypes.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/SpaceTypes.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.knn.index;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -23,8 +24,9 @@ import java.util.Set;
  */
 public enum SpaceTypes {
   l2("l2"),
-  cosinesimil("cosinesimil");
-
+  cosinesimil("cosinesimil"),
+  negdotprod("negdotprod"),
+  bit_hamming("bit_hamming");
   private String value;
 
   SpaceTypes(String value) { this.value = value; }
@@ -48,5 +50,19 @@ public enum SpaceTypes {
       values.add(spaceType.getValue());
     }
     return values;
+  }
+
+  /**
+   * Get space types not supporting optimized index.
+   * https://github.com/nmslib/nmslib/blob/master/python_bindings/README.md#saving-indexes-and-data
+   *
+   * @return set of all stat names
+   */
+  public static Set<String> getOptimizedValues() {
+    return new HashSet<>(Arrays.asList(cosinesimil.getValue(), l2.getValue()));
+  }
+
+  public static Set<String> getStringSpaces() {
+    return new HashSet<>(Arrays.asList(bit_hamming.getValue()));
   }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/SpaceTypes.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/SpaceTypes.java
@@ -62,7 +62,7 @@ public enum SpaceTypes {
     return new HashSet<>(Arrays.asList(cosinesimil.getValue(), l2.getValue()));
   }
 
-  public static Set<String> getStringSpaces() {
+  public static Set<String> getIntSpaces() {
     return new HashSet<>(Arrays.asList(bit_hamming.getValue()));
   }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNN80Codec/KNN80CompoundFormat.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNN80Codec/KNN80CompoundFormat.java
@@ -54,15 +54,26 @@ public class KNN80CompoundFormat extends CompoundFormat {
         Set<String> hnswFiles = si.files().stream().filter(file -> file.endsWith(KNNCodecUtil.HNSW_EXTENSION))
                                      .collect(Collectors.toSet());
 
+        Set<String> hnswdatFiles = si.files().stream()
+                .filter(file -> file.endsWith(KNNCodecUtil.HNSW_EXTENSION + ".dat"))
+                .collect(Collectors.toSet());
+
         Set<String> segmentFiles = new HashSet<>();
         segmentFiles.addAll(si.files());
 
-        if (!hnswFiles.isEmpty()) {
+        if (!hnswFiles.isEmpty() || !hnswdatFiles.isEmpty()) {
             for (String hnswFile: hnswFiles) {
                 String hnswCompoundFile = hnswFile + "c";
                 dir.copyFrom(dir, hnswFile, hnswCompoundFile, context);
             }
+            for (String hnswdatFile: hnswdatFiles) {
+                String suffix = KNNCodecUtil.HNSW_EXTENSION + ".dat";
+                String hnswdatCompoundFile = hnswdatFile.substring(0, hnswdatFile.length()-suffix.length())
+                        + KNNCodecUtil.HNSW_EXTENSION + "c.dat";
+                dir.copyFrom(dir, hnswdatFile, hnswdatCompoundFile, context);
+            }
             segmentFiles.removeAll(hnswFiles);
+            segmentFiles.removeAll(hnswdatFiles);
             si.setFiles(segmentFiles);
         }
         Codec.getDefault().compoundFormat().write(dir, si, context);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -90,30 +90,28 @@ class KNN80DocValuesConsumer extends DocValuesConsumer implements Closeable {
             String indexPath = Paths.get(((FSDirectory) (FilterDirectory.unwrap(state.directory))).getDirectory().toString(),
                     hnswFileName).toString();
 
-
             // Pass the path for the nms library to save the file
             String tempIndexPath = indexPath + TEMP_SUFFIX;
             Map<String, String> fieldAttributes = field.attributes();
             String spaceType = fieldAttributes.getOrDefault(KNNConstants.SPACE_TYPE, SpaceTypes.l2.getValue());
             String[] algoParams = getKNNIndexParams(fieldAttributes);
             KNNCodecUtil.Pair pair;
-            boolean stringSapces = SpaceTypes.getStringSpaces().contains(spaceType);
+            boolean intSpaces = SpaceTypes.getIntSpaces().contains(spaceType);
 
-            if (stringSapces) {
-                pair = KNNCodecUtil.getStrings(values);
+            if (intSpaces) {
+                pair = KNNCodecUtil.getInts(values);
             } else {
                 pair = KNNCodecUtil.getFloats(values);
             }
-            if (pair == null || (pair.vectors.length == 0 && pair.vectorsStr.length == 0) || pair.docs.length == 0) {
+            if (pair == null || (pair.vectors.length == 0 && pair.vectorsInt.length == 0) || pair.docs.length == 0) {
                 logger.info("Skipping hnsw index creation as there are no vectors or docs in the documents");
                 return;
             }
-
             AccessController.doPrivileged(
                     new PrivilegedAction<Void>() {
                         public Void run() {
-                            if (stringSapces) {
-                                KNNIndex.saveIndex(pair.docs, pair.vectorsStr, tempIndexPath, algoParams, spaceType);
+                            if (intSpaces) {
+                                KNNIndex.saveIndex(pair.docs, pair.vectorsInt, tempIndexPath, algoParams, spaceType);
                             } else {
                                 KNNIndex.saveIndex(pair.docs, pair.vectors, tempIndexPath, algoParams, spaceType);
                             }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNNCodecUtil.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNNCodecUtil.java
@@ -34,25 +34,16 @@ public class KNNCodecUtil {
         public Pair(int[] docs, float[][] vectors) {
             this.docs = docs;
             this.vectors = vectors;
-            this.vectorsStr = new String[0];
             this.vectorsInt = new int[0][0];
         }
         public Pair(int[] docs, int[][] vectorsInt) {
             this.docs = docs;
             this.vectorsInt = vectorsInt;
             this.vectors = new float[0][0];
-            this.vectorsStr = new String[0];
-        }
-        public Pair(int[] docs, String[] vectorsStr) {
-            this.docs = docs;
-            this.vectorsStr = vectorsStr;
-            this.vectors = new float[0][0];
-            this.vectorsInt = new int[0][0];
         }
         public int[] docs;
         public float[][] vectors;
         public int[][] vectorsInt;
-        public String[] vectorsStr;
     }
 
     public static KNNCodecUtil.Pair getFloats(BinaryDocValues values) throws IOException {
@@ -90,28 +81,5 @@ public class KNNCodecUtil {
             docIdList.add(doc);
         }
         return new KNNCodecUtil.Pair(docIdList.stream().mapToInt(Integer::intValue).toArray(), vectorList.toArray(new int[][]{}));
-    }
-    public static KNNCodecUtil.Pair getStrings(BinaryDocValues values) throws IOException {
-        ArrayList<String> vectorList = new ArrayList<>();
-        ArrayList<Integer> docIdList = new ArrayList<>();
-        for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
-            BytesRef bytesref = values.binaryValue();
-            try (ByteArrayInputStream byteStream = new ByteArrayInputStream(bytesref.bytes, bytesref.offset, bytesref.length);
-                 ObjectInputStream objectStream = new ObjectInputStream(byteStream)) {
-                float[] vector = (float[]) objectStream.readObject();
-                //[1,0,1,0,1] --> "1 0 1 0 1"
-                char[] charArray = new char[vector.length*2];
-                for (int bit = 0; bit < vector.length; ++bit) {
-                    int oneBit = ((int)(vector[bit]))%2;
-                    charArray[bit*2] = (char) ('0' + oneBit);
-                    charArray[bit*2+1] = ' ';
-                }
-                vectorList.add(String.valueOf(charArray));
-            } catch (ClassNotFoundException e) {
-                throw new RuntimeException(e);
-            }
-            docIdList.add(doc);
-        }
-        return new KNNCodecUtil.Pair(docIdList.stream().mapToInt(Integer::intValue).toArray(), vectorList.toArray(new String[]{}));
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNNCodecUtil.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNNCodecUtil.java
@@ -34,10 +34,16 @@ public class KNNCodecUtil {
         public Pair(int[] docs, float[][] vectors) {
             this.docs = docs;
             this.vectors = vectors;
+            vectorsStr = new String[0];
         }
-
+        public Pair(int[] docs, String[] vectorsStr) {
+            this.docs = docs;
+            this.vectors = new float[0][0];
+            this.vectorsStr = vectorsStr;
+        }
         public int[] docs;
         public float[][] vectors;
+        public String[] vectorsStr;
     }
 
     public static KNNCodecUtil.Pair getFloats(BinaryDocValues values) throws IOException {
@@ -55,5 +61,29 @@ public class KNNCodecUtil {
             docIdList.add(doc);
         }
         return new KNNCodecUtil.Pair(docIdList.stream().mapToInt(Integer::intValue).toArray(), vectorList.toArray(new float[][]{}));
+    }
+
+    public static KNNCodecUtil.Pair getStrings(BinaryDocValues values) throws IOException {
+        ArrayList<String> vectorList = new ArrayList<>();
+        ArrayList<Integer> docIdList = new ArrayList<>();
+        for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+            BytesRef bytesref = values.binaryValue();
+            try (ByteArrayInputStream byteStream = new ByteArrayInputStream(bytesref.bytes, bytesref.offset, bytesref.length);
+                 ObjectInputStream objectStream = new ObjectInputStream(byteStream)) {
+                float[] vector = (float[]) objectStream.readObject();
+                //[1,0,1,0,1] --> "1 0 1 0 1"
+                char[] charArray = new char[vector.length*2];
+                for (int bit = 0; bit < vector.length; ++bit) {
+                    int oneBit = ((int)(vector[bit]))%2;
+                    charArray[bit*2] = (char) ('0' + oneBit);
+                    charArray[bit*2+1] = ' ';
+                }
+                vectorList.add(String.valueOf(charArray));
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+            docIdList.add(doc);
+        }
+        return new KNNCodecUtil.Pair(docIdList.stream().mapToInt(Integer::intValue).toArray(), vectorList.toArray(new String[]{}));
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNNCodecUtil.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNNCodecUtil.java
@@ -34,15 +34,24 @@ public class KNNCodecUtil {
         public Pair(int[] docs, float[][] vectors) {
             this.docs = docs;
             this.vectors = vectors;
-            vectorsStr = new String[0];
+            this.vectorsStr = new String[0];
+            this.vectorsInt = new int[0][0];
+        }
+        public Pair(int[] docs, int[][] vectorsInt) {
+            this.docs = docs;
+            this.vectorsInt = vectorsInt;
+            this.vectors = new float[0][0];
+            this.vectorsStr = new String[0];
         }
         public Pair(int[] docs, String[] vectorsStr) {
             this.docs = docs;
-            this.vectors = new float[0][0];
             this.vectorsStr = vectorsStr;
+            this.vectors = new float[0][0];
+            this.vectorsInt = new int[0][0];
         }
         public int[] docs;
         public float[][] vectors;
+        public int[][] vectorsInt;
         public String[] vectorsStr;
     }
 
@@ -62,7 +71,26 @@ public class KNNCodecUtil {
         }
         return new KNNCodecUtil.Pair(docIdList.stream().mapToInt(Integer::intValue).toArray(), vectorList.toArray(new float[][]{}));
     }
-
+    public static KNNCodecUtil.Pair getInts(BinaryDocValues values) throws IOException {
+        ArrayList<int[]> vectorList = new ArrayList<>();
+        ArrayList<Integer> docIdList = new ArrayList<>();
+        for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+            BytesRef bytesref = values.binaryValue();
+            try (ByteArrayInputStream byteStream = new ByteArrayInputStream(bytesref.bytes, bytesref.offset, bytesref.length);
+                 ObjectInputStream objectStream = new ObjectInputStream(byteStream)) {
+                float[] vector = (float[]) objectStream.readObject();
+                int[] vectorInt = new int[vector.length];
+                for(int i = 0; i < vector.length; ++i) {
+                    vectorInt[i] = (int) vector[i];
+                }
+                vectorList.add(vectorInt);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+            docIdList.add(doc);
+        }
+        return new KNNCodecUtil.Pair(docIdList.stream().mapToInt(Integer::intValue).toArray(), vectorList.toArray(new int[][]{}));
+    }
     public static KNNCodecUtil.Pair getStrings(BinaryDocValues values) throws IOException {
         ArrayList<String> vectorList = new ArrayList<>();
         ArrayList<Integer> docIdList = new ArrayList<>();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/v206/KNNIndex.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/v206/KNNIndex.java
@@ -126,6 +126,7 @@ public class KNNIndex implements AutoCloseable {
         readLock.lock();
         KNNCounter.GRAPH_QUERY_REQUESTS.increment();
         try {
+
             if (this.isClosed) {
                 throw new IOException("Index is already closed");
             }
@@ -198,11 +199,7 @@ public class KNNIndex implements AutoCloseable {
         }
         return new KNNIndex(indexPointer, fileSize, spaceType);
     }
-    public static KNNIndex loadIndexI(String indexPath, final String[] algoParams, final String spaceType) {
-        long fileSize = computeFileSize(indexPath);
-        long indexPointer = initI(indexPath, algoParams, spaceType, false);
-        return new KNNIndex(indexPointer, fileSize, spaceType);
-    }
+
 
     /**
      * determines the size of the hnsw index on disk

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/v206/KNNIndex.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/v206/KNNIndex.java
@@ -149,18 +149,20 @@ public class KNNIndex implements AutoCloseable {
 
     // Builds index and writes to disk (no index pointer escapes).
     public static void saveIndex(int[] ids, float[][] data, String indexPath, String[] algoParams, String spaceType) {
-        //default use optimized index so do not need load index
+        //default use optimized index so do not need store Data, but others need store dataset
         boolean saveData = !SpaceTypes.getOptimizedValues().contains(spaceType);
         saveIndex(ids, data, indexPath, algoParams, spaceType, saveData);
 
     }
     public static void saveIndex(int[] ids, int[][] data, String indexPath, String[] algoParams, String spaceType) {
-        //default use optimized index so do not need load index
-        saveIndexI(ids, data, indexPath, algoParams, spaceType, true);
+        //default use optimized index so do not need store Data, but others need store dataset
+        boolean saveData = !SpaceTypes.getOptimizedValues().contains(spaceType);
+        saveIndexI(ids, data, indexPath, algoParams, spaceType, saveData);
     }
     public static void saveIndex(int[] ids, String[] data, String indexPath, String[] algoParams, String spaceType) {
-        //default use optimized index so do not need load index
-        saveIndexB(ids, data, indexPath, algoParams, spaceType, true);
+        //default use optimized index so do not need store Data, but others need store dataset
+        boolean saveData = !SpaceTypes.getOptimizedValues().contains(spaceType);
+        saveIndexB(ids, data, indexPath, algoParams, spaceType, saveData);
     }
     @Override
     public void close() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/v206/KNNIndex.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/v206/KNNIndex.java
@@ -174,7 +174,12 @@ public class KNNIndex implements AutoCloseable {
             return;
         }
         try {
-            gc(this.indexPointer);
+            boolean intSpaces = SpaceTypes.getIntSpaces().contains(spaceType);
+            if(intSpaces) {
+                gcI(this.indexPointer);
+            } else {
+                gc(this.indexPointer);
+            }
         } finally {
             this.isClosed = true;
             writeLock.unlock();
@@ -191,10 +196,10 @@ public class KNNIndex implements AutoCloseable {
      */
     public static KNNIndex loadIndex(String indexPath, final String[] algoParams, final String spaceType) {
         long fileSize = computeFileSize(indexPath);
-        boolean stringSapces = SpaceTypes.getStringSpaces().contains(spaceType);
+        boolean intSpaces = SpaceTypes.getIntSpaces().contains(spaceType);
         boolean loadData = !SpaceTypes.getOptimizedValues().contains(spaceType);
         long indexPointer;
-        if (stringSapces) {
+        if (intSpaces) {
             indexPointer = initI(indexPath, algoParams, spaceType, loadData);
         } else {
             indexPointer = init(indexPath, algoParams, spaceType, loadData);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNESIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNESIT.java
@@ -236,7 +236,18 @@ public class KNNESIT extends KNNRestTestCase {
         assertThat(ex.getMessage(), containsString("Dimension value cannot be greater than " +
                 KNNVectorFieldMapper.MAX_DIMENSION + " for vector: " + FIELD_NAME));
     }
+    public void testVectorMappingValidationInvalidBitDimension() {
+        Settings settings = Settings.builder()
+                .put(getKNNDefaultIndexSettings())
+                .put(KNNSettings.KNN_SPACE_TYPE, SpaceTypes.bit_hamming.getValue())
+                .build();
 
+        Exception ex = expectThrows(ResponseException.class, () -> createKnnIndex(INDEX_NAME, settings,
+                createKnnIndexMapping(FIELD_NAME, KNNVectorFieldMapper.MAX_DIMENSION * 32+ 1)));
+
+        assertThat(ex.getMessage(), containsString("Bit Dimension value cannot be greater than " +
+                KNNVectorFieldMapper.MAX_DIMENSION * 32 + " for vector: " + FIELD_NAME));
+    }
     public void testVectorMappingValidationInvalidVectorNaN() throws IOException {
         Settings settings = Settings.builder()
                 .put(getKNNDefaultIndexSettings())

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNJNITests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNJNITests.java
@@ -243,7 +243,7 @@ public class KNNJNITests extends KNNTestCase {
         String queryVector = "1 1 1 1";
         String[] algoQueryParams = {"efSearch=20"};
 
-        final KNNIndex knnIndex = KNNIndex.loadIndexI(indexPath, algoQueryParams, "bit_hamming");
+        final KNNIndex knnIndex = KNNIndex.loadIndex(indexPath, algoQueryParams, "bit_hamming");
         final KNNQueryResult[] results = knnIndex.queryIndex(queryVector, 30);
 
         Map<Integer, Float> scores = Arrays.stream(results).collect(

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNJNITests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNJNITests.java
@@ -210,8 +210,61 @@ public class KNNJNITests extends KNNTestCase {
         dir.close();
     }
 
+    public void testAddAndQueryHnswIndexBitHammingWithInt() throws Exception {
+        int[] docs = {0, 1, 2, 3, 4, 5};
 
-    public void testAddAndQueryHnswIndexBitHamming() throws Exception {
+        int[][] vectors = {
+                {0,0,0},   //0*28, 0000, 0*28, 0000, 0*28, 0000
+                {1,0,5},   //0*28, 0001, 0*28, 0000, 0*28, 0101
+                {0,5,1},   //0*28, 0000, 0*28, 0101, 0*28, 0001
+                {8,4,1},   //0*28, 1000, 0*28, 0100, 0*28, 0001
+                {1,1,4},   //0*28, 0001, 0*28, 0001, 0*28, 0100
+                {-1,-1,-1} //1*27, 1111, 1*28, 1111, 1*28, 1111
+        };
+
+        Directory dir = newFSDirectory(createTempDir());
+        String segmentName = "_dummy1";
+        String indexPath = Paths.get(((FSDirectory) (FilterDirectory.unwrap(dir))).getDirectory().toString(),
+                String.format("%s.hnsw", segmentName)).toString();
+
+        String[] algoParams = {};
+        AccessController.doPrivileged(
+                new PrivilegedAction<Void>() {
+                    public Void run() {
+                        KNNIndex.saveIndexI(docs, vectors, indexPath, algoParams, "bit_hamming", true);
+                        return null;
+                    }
+                }
+        );
+
+        assertTrue(Arrays.asList(dir.listAll()).contains("_dummy1.hnsw"));
+        assertTrue(Arrays.asList(dir.listAll()).contains("_dummy1.hnsw.dat"));
+
+        int[] queryVector = {0, 5, 1};
+        String[] algoQueryParams = {"efSearch=20"};
+
+        final KNNIndex knnIndex = KNNIndex.loadIndex(indexPath, algoQueryParams, "bit_hamming");
+        final KNNQueryResult[] results = knnIndex.queryIndex(queryVector, 30);
+
+        Map<Integer, Float> scores = Arrays.stream(results).collect(
+                Collectors.toMap(result -> result.getId(), result -> result.getScore()));
+        logger.info(scores);
+
+        assertEquals(results.length, 6);
+        /*
+         * scores are evaluated using bit_hamming. Distance of the documents with
+         * respect to query vector are as follows
+         * doc0 = 3.0, doc1 = 4.0, doc2 = 0.0, doc3 = 2.0, doc4 = 4.0
+         */
+        assertEquals(scores.get(0), 3.0, 1e-4);
+        assertEquals(scores.get(1), 4.0, 1e-4);
+        assertEquals(scores.get(2), 0.0, 1e-4);
+        assertEquals(scores.get(3), 2.0, 1e-4);
+        assertEquals(scores.get(4), 4.0, 1e-4);
+        assertEquals(scores.get(5), 93.0, 1e-4);
+        dir.close();
+    }
+    public void testAddAndQueryHnswIndexBitHammingWithString() throws Exception {
         int[] docs = {0, 1, 2, 3, 4};
 
         String[] vectors = {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNJNITests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNJNITests.java
@@ -284,7 +284,7 @@ public class KNNJNITests extends KNNTestCase {
         AccessController.doPrivileged(
                 new PrivilegedAction<Void>() {
                     public Void run() {
-                        KNNIndex.saveIndexB(docs, vectors, indexPath, algoParams, "bit_hamming", true);
+                        KNNIndex.saveIndex(docs, vectors, indexPath, algoParams, "bit_hamming");
                         return null;
                     }
                 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNJNITests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNJNITests.java
@@ -160,6 +160,111 @@ public class KNNJNITests extends KNNTestCase {
         dir.close();
     }
 
+    public void testAddAndQueryHnswIndexNegDotProd() throws Exception {
+        int[] docs = {0, 1, 2};
+
+        float[][] vectors = {
+                {1.0f, -1.0f},
+                {-1.0f, 1.0f},
+                {0.0f, 0.0f}
+        };
+
+        Directory dir = newFSDirectory(createTempDir());
+        String segmentName = "_dummy1";
+        String indexPath = Paths.get(((FSDirectory) (FilterDirectory.unwrap(dir))).getDirectory().toString(),
+                String.format("%s.hnsw", segmentName)).toString();
+
+        String[] algoParams = {};
+        AccessController.doPrivileged(
+                new PrivilegedAction<Void>() {
+                    public Void run() {
+                        KNNIndex.saveIndex(docs, vectors, indexPath, algoParams, SpaceTypes.negdotprod.getValue());
+                        return null;
+                    }
+                }
+        );
+
+        assertTrue(Arrays.asList(dir.listAll()).contains("_dummy1.hnsw"));
+        assertTrue(Arrays.asList(dir.listAll()).contains("_dummy1.hnsw.dat"));
+
+        float[] queryVector = {2.0f, -2.0f};
+        String[] algoQueryParams = {"efSearch=20"};
+
+        final KNNIndex knnIndex = KNNIndex.loadIndex(indexPath, algoQueryParams, SpaceTypes.negdotprod.getValue());
+        final KNNQueryResult[] results = knnIndex.queryIndex(queryVector, 30);
+
+        Map<Integer, Float> scores = Arrays.stream(results).collect(
+                Collectors.toMap(result -> result.getId(), result -> result.getScore()));
+        logger.info(scores);
+
+        assertEquals(results.length, 3);
+        /*
+         * scores are evaluated using cosine similarity. Distance of the documents with
+         * respect to query vector are as follows
+         * doc0 = 0.0, doc1 = 0.29289,  doc2 = 1.0
+         * Nearest neighbor is doc1 then doc0 then doc2
+         */
+        assertEquals(scores.get(0), -4.0, 1e-4);
+        assertEquals(scores.get(1), 4.0, 1e-4);
+        assertEquals(scores.get(2), 0.0, 1e-4);
+        dir.close();
+    }
+
+
+    public void testAddAndQueryHnswIndexBitHamming() throws Exception {
+        int[] docs = {0, 1, 2, 3, 4};
+
+        String[] vectors = {
+                "0 0 0 0",
+                "0 0 1 0",
+                "0 1 1 0",
+                "1 0 1 1",
+                "1 1 1 1"
+        };
+
+        Directory dir = newFSDirectory(createTempDir());
+        String segmentName = "_dummy1";
+        String indexPath = Paths.get(((FSDirectory) (FilterDirectory.unwrap(dir))).getDirectory().toString(),
+                String.format("%s.hnsw", segmentName)).toString();
+
+        String[] algoParams = {};
+        AccessController.doPrivileged(
+                new PrivilegedAction<Void>() {
+                    public Void run() {
+                        KNNIndex.saveIndexB(docs, vectors, indexPath, algoParams, "bit_hamming", true);
+                        return null;
+                    }
+                }
+        );
+
+        assertTrue(Arrays.asList(dir.listAll()).contains("_dummy1.hnsw"));
+        assertTrue(Arrays.asList(dir.listAll()).contains("_dummy1.hnsw.dat"));
+
+        String queryVector = "1 1 1 1";
+        String[] algoQueryParams = {"efSearch=20"};
+
+        final KNNIndex knnIndex = KNNIndex.loadIndexI(indexPath, algoQueryParams, "bit_hamming");
+        final KNNQueryResult[] results = knnIndex.queryIndex(queryVector, 30);
+
+        Map<Integer, Float> scores = Arrays.stream(results).collect(
+                Collectors.toMap(result -> result.getId(), result -> result.getScore()));
+        logger.info(scores);
+
+        assertEquals(results.length, 5);
+        /*
+         * scores are evaluated using bit_hamming. Distance of the documents with
+         * respect to query vector are as follows
+         * doc4 = 0.0, doc3 = 1.0, doc2 = 2.0, doc1 = 3.0, doc4 = 4.0
+         * Nearest neighbor is doc1 then doc0 then doc2
+         */
+        assertEquals(scores.get(0), 4.0, 1e-4);
+        assertEquals(scores.get(1), 3.0, 1e-4);
+        assertEquals(scores.get(2), 2.0, 1e-4);
+        assertEquals(scores.get(3), 1.0, 1e-4);
+        assertEquals(scores.get(4), 0.0, 1e-4);
+        dir.close();
+    }
+
     public void testAssertExceptionFromJni() throws Exception {
 
         Directory dir = newFSDirectory(createTempDir());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNMapperSearcherIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNMapperSearcherIT.java
@@ -21,6 +21,8 @@ import org.apache.http.util.EntityUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.common.settings.Settings;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -113,7 +115,64 @@ public class KNNMapperSearcherIT extends KNNRestTestCase {
         assertEquals(actualDocids.size(), k);
         assertArrayEquals(actualDocids.toArray(), expectedDocids.toArray());
     }
+    public void testKNNResultsWithNonOptimizedIndexAndForceMerge() throws Exception {
+        Settings settings = Settings.builder()
+                .put(getKNNDefaultIndexSettings())
+                .put(KNNSettings.KNN_SPACE_TYPE, SpaceTypes.negdotprod.getValue())
+                .build();
+        createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, 2));
+        Float[] vector1 = {-6.0f, -6.0f};
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, vector1);
+        Float[] vector2 = {6.0f, 6.0f};
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, vector2);
+        Float[] vector3 = {-3.0f, -3.0f};
+        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, vector3);
+        forceMergeKnnIndex(INDEX_NAME);
 
+        float[] queryVector = {1.0f, 1.0f}; // vector to be queried
+        int k = 2; //  nearest 1 neighbor
+        KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder(FIELD_NAME, queryVector, k);
+        Response searchResponse = searchKNNIndex(INDEX_NAME, knnQueryBuilder, k);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), FIELD_NAME);
+        List<String> expectedDocids = Arrays.asList("2", "3");
+
+        List<String> actualDocids = new ArrayList<>();
+        for(KNNResult result : results) {
+            actualDocids.add(result.getDocId());
+        }
+
+        assertEquals(actualDocids.size(), k);
+        assertArrayEquals(actualDocids.toArray(), expectedDocids.toArray());
+    }
+    public void testKNNResultsWithNonOptimizedBitHammingIndexAndForceMerge() throws Exception {
+        Settings settings = Settings.builder()
+                .put(getKNNDefaultIndexSettings())
+                .put(KNNSettings.KNN_SPACE_TYPE, SpaceTypes.bit_hamming.getValue())
+                .build();
+        createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, 3));
+        Float[] vector1 = {0.0f, 1.0f, 0.0f};
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, vector1);
+        Float[] vector2 = {1.0f, 0.0f, 1.0f};
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, vector2);
+        Float[] vector3 = {0.0f, 0.0f, 1.0f};
+        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, vector3);
+        forceMergeKnnIndex(INDEX_NAME);
+
+        float[] queryVector = {1.0f, 1.0f, 1.0f}; // vector to be queried
+        int k = 3; //  nearest 1 neighbor
+        KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder(FIELD_NAME, queryVector, k);
+        Response searchResponse = searchKNNIndex(INDEX_NAME, knnQueryBuilder, k);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), FIELD_NAME);
+        List<String> expectedDocids = Arrays.asList("2", "3", "1");
+
+        List<String> actualDocids = new ArrayList<>();
+        for(KNNResult result : results) {
+            actualDocids.add(result.getDocId());
+        }
+
+        assertEquals(actualDocids.size(), k);
+        assertArrayEquals(actualDocids.toArray(), expectedDocids.toArray());
+    }
     public void testKNNResultsWithNewDoc() throws Exception {
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
         addTestData();
@@ -148,6 +207,54 @@ public class KNNMapperSearcherIT extends KNNRestTestCase {
          * Add new doc with vector nearest than doc 2 to queryVector
          */
         Float[] newVector1  = {0.5f, 0.5f};
+        addKnnDoc(INDEX_NAME, "7", FIELD_NAME, newVector1);
+        response = searchKNNIndex(INDEX_NAME, knnQueryBuilder,k);
+        results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
+
+        assertEquals(results.size(), k);
+        for(KNNResult result : results) {
+            assertEquals("7", result.getDocId());
+        }
+    }
+
+    public void testKNNResultsWithNonOptimizedIndexAndNewDoc() throws Exception {
+        Settings settings = Settings.builder()
+                .put(getKNNDefaultIndexSettings())
+                .put(KNNSettings.KNN_SPACE_TYPE, SpaceTypes.negdotprod.getValue())
+                .build();
+        createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, 2));
+        addTestData();
+
+        float[] queryVector = {1.0f, 1.0f}; // vector to be queried
+        int k = 1; //  nearest 1 neighbor
+
+        KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder(FIELD_NAME, queryVector, k);
+        Response response = searchKNNIndex(INDEX_NAME, knnQueryBuilder,k);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
+
+        assertEquals(results.size(), k);
+        for(KNNResult result : results) {
+            assertEquals("1", result.getDocId()); //Vector of DocId 1 is closest to the query
+        }
+
+        /**
+         * Add new doc with vector not nearest than doc 1
+         */
+        Float[] newVector  = {5.0f, 6.0f};
+        addKnnDoc(INDEX_NAME, "6", FIELD_NAME, newVector);
+        response = searchKNNIndex(INDEX_NAME, knnQueryBuilder,k);
+        results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
+
+        assertEquals(results.size(), k);
+        for(KNNResult result : results) {
+            assertEquals("1", result.getDocId());
+        }
+
+
+        /**
+         * Add new doc with vector nearest than doc 1 to queryVector
+         */
+        Float[] newVector1  = {7.0f, 6.0f};
         addKnnDoc(INDEX_NAME, "7", FIELD_NAME, newVector1);
         response = searchKNNIndex(INDEX_NAME, knnQueryBuilder,k);
         results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
@@ -215,6 +322,41 @@ public class KNNMapperSearcherIT extends KNNRestTestCase {
         assertEquals(results.size(), k);
         for(KNNResult result : results) {
             assertEquals("4", result.getDocId()); //Vector of DocId 4 is closest to the query
+        }
+    }
+
+    public void testKNNResultsWithNonOptimizedIndexAndDeleteDoc() throws Exception {
+        Settings settings = Settings.builder()
+                .put(getKNNDefaultIndexSettings())
+                .put(KNNSettings.KNN_SPACE_TYPE, SpaceTypes.negdotprod.getValue())
+                .build();
+        createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, 2));
+        addTestData();
+
+        float[] queryVector = {1.0f, 1.0f}; // vector to be queried
+        int k = 1; //  nearest 1 neighbor
+        KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder(FIELD_NAME, queryVector, k);
+        Response response = searchKNNIndex(INDEX_NAME, knnQueryBuilder, k);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
+
+        assertEquals(results.size(), k);
+        for(KNNResult result : results) {
+            assertEquals("1", result.getDocId()); //Vector of DocId 1 is closest to the query
+        }
+
+
+        /**
+         * delete the nearest doc (doc1)
+         */
+        deleteKnnDoc(INDEX_NAME, "1");
+
+        knnQueryBuilder = new KNNQueryBuilder(FIELD_NAME, queryVector, k+1);
+        response = searchKNNIndex(INDEX_NAME, knnQueryBuilder,k);
+        results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
+
+        assertEquals(results.size(), k);
+        for(KNNResult result : results) {
+            assertEquals("3", result.getDocId()); //Vector of DocId 3 is closest to the query
         }
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNNCodecTestCase.java
@@ -142,7 +142,8 @@ public class  KNNCodecTestCase extends KNNTestCase {
         IndexReader reader = writer.getReader();
         writer.close();
         KNNIndexCache.setResourceWatcherService(createDisabledResourceWatcherService());
-        List<String> hnswfiles = Arrays.stream(dir.listAll()).filter(x -> x.contains("hnsw")).collect(Collectors.toList());
+        List<String> hnswfiles = Arrays.stream(dir.listAll()).filter(x -> x.contains("hnsw") && !x.endsWith(".dat"))
+                .collect(Collectors.toList());
 
         // there should be 2 hnsw index files created. one for test_vector and one for my_vector
         assertEquals(hnswfiles.size(), 2);


### PR DESCRIPTION
*Issue #283,

*Description of changes:*

As I see #264  that add Hamming distance in custom scoring it is a great functionality. i see there is bit_hamming space [space_bit_hamming](https://github.com/nmslib/nmslib/blob/master/similarity_search/include/factory/space/space_bit_hamming.h) in nmslib. i think we can add this into plugin.

i refer to the code [space_bit_hamming](https://github.com/nmslib/nmslib/blob/master/similarity_search/include/factory/space/space_bit_hamming.h) and [space_bit_hamming_test](https://github.com/nmslib/nmslib/blob/master/similarity_search/test/test_space_serial.cc#L231), may be we could add "**SpaceBitVector**" into plugin and support bit_hamming space which is no optimized index.

i also refer to PR: #161 which add no optimized index for "negdotprod", i see the nmslib's python_binding code [python_binding_nmslib](https://github.com/nmslib/nmslib/blob/master/python_bindings/nmslib.cc#L115), may be we could add a "save_data" into plugin and can store index and dataset for "no optimized index". 

so, i submit this PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
