### PR TITLE
Add builder constructor that takes algo params

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNVectorFieldMapper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNVectorFieldMapper.java
@@ -101,8 +101,19 @@ public class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                 }, m -> toType(m).dimension);
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
 
+        private String spaceType;
+        private String m;
+        private String efConstruction;
+
         public Builder(String name) {
             super(name);
+        }
+
+        public Builder(String name, String spaceType, String m, String efConstruction) {
+            super(name);
+            this.spaceType = spaceType;
+            this.m = m;
+            this.efConstruction = efConstruction;
         }
 
         @Override
@@ -122,10 +133,21 @@ public class KNNVectorFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         public KNNVectorFieldMapper build(BuilderContext context) {
+            if (this.spaceType == null) {
+                this.spaceType = getSpaceType(context.indexSettings());
+            }
+
+            if (this.m == null) {
+                this.m = getM(context.indexSettings());
+            }
+
+            if (this.efConstruction == null) {
+                this.efConstruction = getEfConstruction(context.indexSettings());
+            }
+
             return new KNNVectorFieldMapper(name, new KNNVectorFieldType(buildFullName(context), meta.getValue(),
                     dimension.getValue()), multiFieldsBuilder.build(this, context),
-                    ignoreMalformed(context), getSpaceType(context.indexSettings()), getM(context.indexSettings()),
-                    getEfConstruction(context.indexSettings()), copyTo.build(), this);
+                    ignoreMalformed(context), this.spaceType, this.m, this.efConstruction, copyTo.build(), this);
         }
 
         private String getSpaceType(Settings indexSettings) {
@@ -346,7 +368,7 @@ public class KNNVectorFieldMapper extends ParametrizedFieldMapper {
 
     @Override
     public ParametrizedFieldMapper.Builder getMergeBuilder() {
-        return new KNNVectorFieldMapper.Builder(simpleName()).init(this);
+        return new KNNVectorFieldMapper.Builder(simpleName(), this.spaceType, this.m, this.efConstruction).init(this);
     }
 
     @Override


### PR DESCRIPTION
*Issue #, if available:*
#288 

*Description of changes:*
In this PR, I added a constructor for KNNVectorFieldMapper.Builder that takes the algorithm parameters that it typically reads from settings. This constructor is used during merging of mappers. It allows an existing KNNVectorFieldMapper to pass settings to a KNNVectorFieldMapper.Builder for merge.  It plays a similar role to the `ParametrizedFieldMapper.init` method, which copies mapping parameters from an already existing FieldMapper to the FieldMapper.Builder that will be used for merging. I decided to not override this method because it is more focused on mapping parameters, but I am open to feedback on this.

Verified that with this change, I am unable to reproduce the issue following the steps in #288.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
