### PR TITLE
Change CD workflow to use new staging bucket for artifacts

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           ./gradlew buildPackages --console=plain -Dbuild.snapshot=false
 
-      - name: Upload to S3
+      - name: Upload plugin artifacts to S3
         shell: bash
         run: |
           zip=`ls build/distributions/*.zip`
@@ -133,7 +133,7 @@ jobs:
           cp ../release/*.so $folder_name
           zip -r $zip_name $folder_name/*
 
-      - name: Upload to S3
+      - name: Upload JNI library x64 artifacts to S3
         shell: bash
         run: |
           zip=`ls jni/packages/*.zip`
@@ -196,7 +196,7 @@ jobs:
           sudo ./aws/install
           aws --version
 
-      - name: Build and ship library artifacts
+      - name: Build
         env:
           CXX: ${{ matrix.compiler }}
         run: |
@@ -215,7 +215,7 @@ jobs:
           cp ../release/*.so $folder_name
           zip -r $zip_name $folder_name/*
 
-      - name: Upload to S3
+      - name: Upload JNI library arm64 artifacts to S3
         shell: bash
         run: |
           zip=`ls jni/packages/*.zip`

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,8 +1,11 @@
 name: Build and Release k-NN
 on:
+  # push:
+  #   tags:
+  #     - v*
   push:
-    tags:
-      - v*
+    branches:
+      - "release-workflow-patch"
 
 jobs:
   Provision-Runners:
@@ -43,8 +46,8 @@ jobs:
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
       - name: Setup Java ${{ matrix.java }}
@@ -52,17 +55,32 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
 
-      - name: Build and ship plugin artifacts
+      - name: Build
         run: |
           ./gradlew buildPackages --console=plain -Dbuild.snapshot=false
-          artifact=`ls build/distributions/*.zip`
-          rpm_artifact=`ls build/distributions/*.rpm`
-          deb_artifact=`ls build/distributions/*.deb`
 
-          aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-plugins/opendistro-knn/
-          aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-knn/
-          aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-knn/
-          aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"
+      - name: Upload to S3
+        shell: bash
+        run: |
+          zip=`ls build/distributions/*.zip`
+          rpm=`ls build/distributions/*.rpm`
+          deb=`ls build/distributions/*.deb`
+
+          # Inject the build number before the suffix
+          zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+          rpm_outfile=`basename ${rpm%.rpm}-build-${GITHUB_RUN_NUMBER}.rpm`
+          deb_outfile=`basename ${deb%.deb}-build-${GITHUB_RUN_NUMBER}.deb`
+
+          s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/elasticsearch-plugins/knn/"
+
+          echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
+          aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}
+
+          echo "Copying ${rpm} to ${s3_prefix}${rpm_outfile}"
+          aws s3 cp --quiet $rpm ${s3_prefix}${rpm_outfile}
+
+          echo "Copying ${deb} to ${s3_prefix}${deb_outfile}"
+          aws s3 cp --quiet $deb ${s3_prefix}${deb_outfile}
 
   library-build-and-ship-artifacts-x64:
     name: Build and release JNI library artifacts x64
@@ -82,8 +100,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
       - name: Setup Java ${{ matrix.java }}
@@ -102,7 +120,7 @@ jobs:
           ./aws/install
           aws --version
 
-      - name: Build and ship library artifacts
+      - name: Build
         env:
           CXX: ${{ matrix.compiler }}
         run: |
@@ -117,16 +135,29 @@ jobs:
           mkdir $folder_name
           cp ../release/*.so $folder_name
           zip -r $zip_name $folder_name/*
-          cd ..
 
-          zip_artifact=`ls packages/*.zip`
-          rpm_artifact=`ls packages/*.rpm`
-          deb_artifact=`ls packages/*.deb`
+      - name: Upload to S3
+        shell: bash
+        run: |
+          zip=`ls jni/packages/*.zip`
+          rpm=`ls jni/packages/*.rpm`
+          deb=`ls jni/packages/*.deb`
 
-          aws s3 cp $zip_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/opendistro-libs/opendistro-knnlib/
-          aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-knnlib/
-          aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-knnlib/
-          aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"
+          # Inject the build number before the suffix
+          zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+          rpm_outfile=`basename ${rpm%.rpm}-build-${GITHUB_RUN_NUMBER}.rpm`
+          deb_outfile=`basename ${deb%.deb}-build-${GITHUB_RUN_NUMBER}.deb`
+
+          s3_lib_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/opendistro-libs/knnlib/"
+
+          echo "Copying ${zip} to ${s3_lib_prefix}${zip_outfile}"
+          aws s3 cp --quiet $zip ${s3_lib_prefix}${zip_outfile}
+
+          echo "Copying ${rpm} to ${s3_lib_prefix}${rpm_outfile}"
+          aws s3 cp --quiet $rpm ${s3_lib_prefix}${rpm_outfile}
+
+          echo "Copying ${deb} to ${s3_lib_prefix}${deb_outfile}"
+          aws s3 cp --quiet $deb ${s3_lib_prefix}${deb_outfile}
 
   library-build-and-ship-artifacts-arm64:
     needs: [Provision-Runners]
@@ -145,8 +176,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
       # Arm64 is not supported by setup-java actions as of now
@@ -186,19 +217,29 @@ jobs:
           mkdir $folder_name
           cp ../release/*.so $folder_name
           zip -r $zip_name $folder_name/*
-          cd ..
 
-          zip_artifact=`ls packages/*.zip`
-          rpm_artifact=`ls packages/*.rpm`
-          deb_artifact=`ls packages/*.deb`
+      - name: Upload to S3
+        shell: bash
+        run: |
+          zip=`ls jni/packages/*.zip`
+          rpm=`ls jni/packages/*.rpm`
+          deb=`ls jni/packages/*.deb`
 
-          ls -l packages/
+          # Inject the build number before the suffix
+          zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+          rpm_outfile=`basename ${rpm%.rpm}-build-${GITHUB_RUN_NUMBER}.rpm`
+          deb_outfile=`basename ${deb%.deb}-build-${GITHUB_RUN_NUMBER}.deb`
 
+          s3_lib_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/opendistro-libs/knnlib/"
 
-          aws s3 cp $zip_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/opendistro-libs/opendistro-knnlib/
-          aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-knnlib/
-          aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-knnlib/
-          aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"
+          echo "Copying ${zip} to ${s3_lib_prefix}${zip_outfile}"
+          aws s3 cp --quiet $zip ${s3_lib_prefix}${zip_outfile}
+
+          echo "Copying ${rpm} to ${s3_lib_prefix}${rpm_outfile}"
+          aws s3 cp --quiet $rpm ${s3_lib_prefix}${rpm_outfile}
+
+          echo "Copying ${deb} to ${s3_lib_prefix}${deb_outfile}"
+          aws s3 cp --quiet $deb ${s3_lib_prefix}${deb_outfile}
 
   CleanUp-Runners:
     needs: [library-build-and-ship-artifacts-arm64]

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,11 +1,8 @@
 name: Build and Release k-NN
 on:
-  # push:
-  #   tags:
-  #     - v*
   push:
-    branches:
-      - "release-workflow-patch"
+    tags:
+      - v*
 
 jobs:
   Provision-Runners:


### PR DESCRIPTION
Description of changes:
The infrastructure team is separating the production and staging locations into different AWS accounts. Plugins need to modify their workflows to publish to the new locations.

This PR changes the CD workflow to add a build number and write the zip, deb, and rpm plugin artifacts to staging.artifacts.opendistroforelasticsearch.amazon.com.

Test Result: https://github.com/opendistro-for-elasticsearch/k-NN/runs/1685141609?check_suite_focus=true

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.