### PR TITLE
Update artifact naming

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -268,14 +268,27 @@ afterEvaluate {
 
     buildRpm {
         arch = 'NOARCH'
-        archiveName "${packageName}-${version}.rpm"
         dependsOn 'assemble'
+        finalizedBy 'renameRpm'
+        task renameRpm(type: Copy) {
+            from("$buildDir/distributions")
+            into("$buildDir/distributions")
+            include archiveName
+            rename archiveName, "${packageName}-${version}.rpm"
+            doLast { delete file("$buildDir/distributions/$archiveName") }
+        }
     }
-
     buildDeb {
-        arch = 'amd64'
-        archiveName "${packageName}-${version}.deb"
+        arch = 'all'
         dependsOn 'assemble'
+        finalizedBy 'renameDeb'
+        task renameDeb(type: Copy) {
+            from("$buildDir/distributions")
+            into("$buildDir/distributions")
+            include archiveName
+            rename archiveName, "${packageName}-${version}.deb"
+            doLast { delete file("$buildDir/distributions/$archiveName") }
+        }
     }
 
     task buildPackages(type: GradleBuild) {

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -76,7 +76,7 @@ elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL x86_64)
 endif()
 
 set(KNN_MAINTAINER "OpenDistro for Elasticsearch Team <opendistro@amazon.com>")
-set(ODFE_DOWNLOAD_URL "https://opendistro.github.io/elasticsearch/downloads")
+set(ODFE_DOWNLOAD_URL "https://opendistro.github.io/for-elasticsearch/downloads.html")
 set(CPACK_PACKAGE_NAME ${KNN_PACKAGE_NAME})
 set(CPACK_PACKAGE_VERSION 1.12.0.0)
 set(CMAKE_INSTALL_PREFIX /usr)

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -69,6 +69,12 @@ install(TARGETS ${KNN_INDEX}
         COMPONENT library)
 
 # CPack section to build artifacts
+if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL aarch64)
+    set(MACH_ARCH arm64)
+elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL x86_64)
+    set(MACH_ARCH x64)
+endif()
+
 set(KNN_MAINTAINER "OpenDistro for Elasticsearch Team <opendistro@amazon.com>")
 set(ODFE_DOWNLOAD_URL "https://opendistro.github.io/elasticsearch/downloads")
 set(CPACK_PACKAGE_NAME ${KNN_PACKAGE_NAME})
@@ -81,7 +87,7 @@ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "KNN JNI library built off of NMSLIB for O
 set(CPACK_PACKAGE_VENDOR "Amazon")
 set(CPACK_PACKAGE_CONTACT "Maintainer: ${KNN_MAINTAINER}")
 set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
-set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${JVM_OS_TYPE}-${CMAKE_SYSTEM_PROCESSOR}")
+set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${JVM_OS_TYPE}-${MACH_ARCH}")
 
 # RPM Specific variables
 set(CPACK_RPM_PACKAGE_RELEASE ${CPACK_PACKAGE_RELEASE})


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR updates the k-NN plugins artifacts with the naming conventions set by the infrastructure team.

The new artifacts look like this:
```
opendistro-knn-1.12.0.0.rpm
opendistro-knn-1.12.0.0.deb
opendistro-knnlib-1.12.0.0-linux-arm64.deb
opendistro-knnlib-1.12.0.0-linux-arm64.rpm
opendistro-knnlib-1.12.0.0-linux-x64.deb
opendistro-knnlib-1.12.0.0-linux-x64.rpm
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
