### PR TITLE
Change mode for jni arrays release to prevent unnecessary copy backs

### DIFF
--- a/jni/src/com_amazon_opendistroforelasticsearch_knn_index_v2011_KNNIndex.cpp
+++ b/jni/src/com_amazon_opendistroforelasticsearch_knn_index_v2011_KNNIndex.cpp
@@ -103,10 +103,10 @@ JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v201
             jfloatArray vectorArray = (jfloatArray)env->GetObjectArrayElement(vectors, i);
             float* vector = env->GetFloatArrayElements(vectorArray, 0);
             dataset.push_back(new Object(object_ids[i], -1, env->GetArrayLength(vectorArray)*sizeof(float), vector));
-            env->ReleaseFloatArrayElements(vectorArray, vector, 0);
+            env->ReleaseFloatArrayElements(vectorArray, vector, JNI_ABORT);
         }
         // free up memory
-        env->ReleaseIntArrayElements(ids, object_ids, 0);
+        env->ReleaseIntArrayElements(ids, object_ids, JNI_ABORT);
         index = MethodFactoryRegistry<float>::Instance().CreateMethod(false, "hnsw", spaceTypeString, *space, dataset);
 
         int paramsCount = env->GetArrayLength(algoParams);
@@ -134,7 +134,7 @@ JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v201
         delete space;
     }
     catch (...) {
-        if (object_ids) { env->ReleaseIntArrayElements(ids, object_ids, 0); }
+        if (object_ids) { env->ReleaseIntArrayElements(ids, object_ids, JNI_ABORT); }
         for (auto it = dataset.begin(); it != dataset.end(); it++) {
              delete *it;
         }
@@ -151,7 +151,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_amazon_opendistroforelasticsearch_knn_in
 
         float* rawQueryvector = env->GetFloatArrayElements(queryVector, 0);
         std::unique_ptr<const Object> queryObject(new Object(-1, -1, env->GetArrayLength(queryVector)*sizeof(float), rawQueryvector));
-        env->ReleaseFloatArrayElements(queryVector, rawQueryvector, 0);
+        env->ReleaseFloatArrayElements(queryVector, rawQueryvector, JNI_ABORT);
         has_exception_in_stack(env);
 
         KNNQuery<float> knnQuery(*(indexWrapper->space), queryObject.get(), k);
@@ -231,5 +231,4 @@ JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v201
 JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v2011_KNNIndex_initLibrary(JNIEnv *, jclass)
 {
     initLibrary();
-
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Small improvement to JNI layer. For background, once native code no longer needs access to one of the Java components, release has to be called to inform VM that the native code does not need to access it any longer. For primitive arrays, the JNI will either pin the Java array in memory and give the native code a handle to it, or it will create a copy. 

For arrays, the last argument is mode. mode has no impact if the array is not a copy. If it is a copy, mode determines how the release should be handled. We pass "0" which will copy the copy back and then free the buffer. Because we do not change the array, this is unnecessary; instead we can pass JNI_ABORT, which just frees the buffer. 

For more information, please refer to https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#Release_PrimitiveType_ArrayElements_routines.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
