### PR TITLE
Abstract out components and clean up JNI layer to more easily support additional libraries

### DIFF
--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -55,7 +55,7 @@ else()
 endif()
 
 # Compile the library
-add_library(${KNN_INDEX} SHARED ${CMAKE_CURRENT_SOURCE_DIR}/src/com_amazon_opendistroforelasticsearch_knn_index_v2011_KNNIndex.cpp)
+add_library(${KNN_INDEX} SHARED ${CMAKE_CURRENT_SOURCE_DIR}/src/com_amazon_opendistroforelasticsearch_knn_index_v2011_KNNIndex.cpp include/jni_util.h)
 target_link_libraries(${KNN_INDEX} NonMetricSpaceLib)
 target_include_directories(${KNN_INDEX} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include $ENV{JAVA_HOME}/include $ENV{JAVA_HOME}/include/${JVM_OS_TYPE} ${CMAKE_CURRENT_SOURCE_DIR}/external/nmslib/similarity_search/include)
 

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -55,7 +55,7 @@ else()
 endif()
 
 # Compile the library
-add_library(${KNN_INDEX} SHARED ${CMAKE_CURRENT_SOURCE_DIR}/src/com_amazon_opendistroforelasticsearch_knn_index_v2011_KNNIndex.cpp include/jni_util.h)
+add_library(${KNN_INDEX} SHARED ${CMAKE_CURRENT_SOURCE_DIR}/src/com_amazon_opendistroforelasticsearch_knn_index_v2011_KNNIndex.cpp include/jni_util.h src/jni_util.cpp)
 target_link_libraries(${KNN_INDEX} NonMetricSpaceLib)
 target_include_directories(${KNN_INDEX} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include $ENV{JAVA_HOME}/include $ENV{JAVA_HOME}/include/${JVM_OS_TYPE} ${CMAKE_CURRENT_SOURCE_DIR}/external/nmslib/similarity_search/include)
 

--- a/jni/include/jni_util.h
+++ b/jni/include/jni_util.h
@@ -17,8 +17,9 @@
 #define OPENDISTRO_KNN_JNI_UTIL_H
 
 #include <jni.h>
-#include <stdexcept>
 #include <new>
+#include <stdexcept>
+#include <string>
 
 void java_exception(JNIEnv* env, const char* type = "", const char* message = "") {
     jclass newExcCls = env->FindClass(type);
@@ -52,6 +53,16 @@ void catch_cpp_exception_and_throw_java(JNIEnv* env)
     catch (...) {
         java_exception(env, "java/lang/Exception", "Unknown exception occurred");
     }
+}
+
+std::string getStringJenv(JNIEnv * env, jstring javaString) {
+    const char *cString = env->GetStringUTFChars(javaString, nullptr);
+    if (cString == nullptr) {
+        has_exception_in_stack(env);
+    }
+    std::string cppString(cString);
+    env->ReleaseStringUTFChars(javaString, cString);
+    return cppString;
 }
 
 #endif //OPENDISTRO_KNN_JNI_UTIL_H

--- a/jni/include/jni_util.h
+++ b/jni/include/jni_util.h
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-void java_exception(JNIEnv* env, const char* type = "", const char* message = "") {
+void ThrowJavaException(JNIEnv* env, const char* type = "", const char* message = "") {
     jclass newExcCls = env->FindClass(type);
     if (newExcCls != nullptr) {
         env->ThrowNew(newExcCls, message);
@@ -32,49 +32,49 @@ void java_exception(JNIEnv* env, const char* type = "", const char* message = ""
 
 // This method checks if an exception occurred in the JVM and if so throws a C++ exception
 // This should be called after some calls to JNI functions
-inline void has_exception_in_stack(JNIEnv* env)
+inline void HasExceptionInStack(JNIEnv* env)
 {
     if (env->ExceptionCheck() == JNI_TRUE) {
         throw std::runtime_error("Exception Occurred");
     }
 }
 
-void catch_cpp_exception_and_throw_java(JNIEnv* env)
+void CatchCppExceptionAndThrowJava(JNIEnv* env)
 {
     try {
         throw;
     }
     catch (const std::bad_alloc& rhs) {
-        java_exception(env, "java/io/IOException", rhs.what());
+        ThrowJavaException(env, "java/io/IOException", rhs.what());
     }
     catch (const std::runtime_error& re) {
-        java_exception(env, "java/lang/Exception", re.what());
+        ThrowJavaException(env, "java/lang/Exception", re.what());
     }
     catch (const std::exception& e) {
-        java_exception(env, "java/lang/Exception", e.what());
+        ThrowJavaException(env, "java/lang/Exception", e.what());
     }
     catch (...) {
-        java_exception(env, "java/lang/Exception", "Unknown exception occurred");
+        ThrowJavaException(env, "java/lang/Exception", "Unknown exception occurred");
     }
 }
 
-std::string getStringJenv(JNIEnv * env, jstring javaString) {
+std::string GetStringJenv(JNIEnv * env, jstring javaString) {
     const char *cString = env->GetStringUTFChars(javaString, nullptr);
     if (cString == nullptr) {
-        has_exception_in_stack(env);
+        HasExceptionInStack(env);
     }
     std::string cppString(cString);
     env->ReleaseStringUTFChars(javaString, cString);
     return cppString;
 }
 
-std::vector<std::string> getVectorOfStrings(JNIEnv * env, jobjectArray javaStringsArray) {
+std::vector<std::string> GetVectorOfStrings(JNIEnv * env, jobjectArray javaStringsArray) {
     int arraySize = env->GetArrayLength(javaStringsArray);
     std::vector<std::string> stringVector;
     std::string cppString;
 
     for (int i=0; i < arraySize; i++) {
-        cppString = getStringJenv(env, (jstring)(env->GetObjectArrayElement(javaStringsArray, i)));
+        cppString = GetStringJenv(env, (jstring)(env->GetObjectArrayElement(javaStringsArray, i)));
         stringVector.push_back(cppString);
     }
 

--- a/jni/include/jni_util.h
+++ b/jni/include/jni_util.h
@@ -22,32 +22,33 @@
 #include <string>
 #include <vector>
 
+namespace knn_jni {
+    // Takes the name of a Java exception type and a message and throws the corresponding exception
+    // to the JVM
+    void ThrowJavaException(JNIEnv* env, const char* type = "", const char* message = "");
 
-// Takes the name of a Java exception type and a message and throws the corresponding exception
-// to the JVM
-void ThrowJavaException(JNIEnv* env, const char* type = "", const char* message = "");
 
-
-// Checks if an exception occurred in the JVM and if so throws a C++ exception
-// This should be called after some calls to JNI functions
-inline void HasExceptionInStack(JNIEnv* env)
-{
-    if (env->ExceptionCheck() == JNI_TRUE) {
-        throw std::runtime_error("Exception Occurred");
+    // Checks if an exception occurred in the JVM and if so throws a C++ exception
+    // This should be called after some calls to JNI functions
+    inline void HasExceptionInStack(JNIEnv* env)
+    {
+        if (env->ExceptionCheck() == JNI_TRUE) {
+            throw std::runtime_error("Exception Occurred");
+        }
     }
+
+
+    // Catches a C++ exception and throws the corresponding exception to the JVM
+    void CatchCppExceptionAndThrowJava(JNIEnv* env);
+
+
+    // Returns cpp copied string from the Java string and releases the JNI Resource
+    std::string GetStringJenv(JNIEnv * env, jstring javaString);
+
+
+    // Returns the translation of a jobjectArray containing jstrings to a c++ vector of strings and releases the underlying
+    // JNI resources
+    std::vector<std::string> GetVectorOfStrings(JNIEnv * env, jobjectArray javaStringsArray);
 }
-
-
-// Catches a C++ exception and throws the corresponding exception to the JVM
-void CatchCppExceptionAndThrowJava(JNIEnv* env);
-
-
-// Returns cpp copied string from the Java string and releases the JNI Resource
-std::string GetStringJenv(JNIEnv * env, jstring javaString);
-
-
-// Returns the translation of a jobjectArray containing jstrings to a c++ vector of strings and releases the underlying
-// JNI resources
-std::vector<std::string> GetVectorOfStrings(JNIEnv * env, jobjectArray javaStringsArray);
 
 #endif //OPENDISTRO_KNN_JNI_UTIL_H

--- a/jni/include/jni_util.h
+++ b/jni/include/jni_util.h
@@ -20,6 +20,7 @@
 #include <new>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 void java_exception(JNIEnv* env, const char* type = "", const char* message = "") {
     jclass newExcCls = env->FindClass(type);
@@ -65,6 +66,19 @@ std::string getStringJenv(JNIEnv * env, jstring javaString) {
     std::string cppString(cString);
     env->ReleaseStringUTFChars(javaString, cString);
     return cppString;
+}
+
+std::vector<std::string> getVectorOfStrings(JNIEnv * env, jobjectArray javaStringsArray) {
+    int arraySize = env->GetArrayLength(javaStringsArray);
+    std::vector<std::string> stringVector;
+    std::string cppString;
+
+    for (int i=0; i < arraySize; i++) {
+        cppString = getStringJenv(env, (jstring)(env->GetObjectArrayElement(javaStringsArray, i)));
+        stringVector.push_back(cppString);
+    }
+
+    return stringVector;
 }
 
 #endif //OPENDISTRO_KNN_JNI_UTIL_H

--- a/jni/include/jni_util.h
+++ b/jni/include/jni_util.h
@@ -26,9 +26,11 @@ void java_exception(JNIEnv* env, const char* type = "", const char* message = ""
     if (newExcCls != nullptr) {
         env->ThrowNew(newExcCls, message);
     }
-    //If newExcCls isn't found, NoClassDefFoundError will be thrown
+    // If newExcCls isn't found, NoClassDefFoundError will be thrown
 }
 
+// This method checks if an exception occurred in the JVM and if so throws a C++ exception
+// This should be called after some calls to JNI functions
 inline void has_exception_in_stack(JNIEnv* env)
 {
     if (env->ExceptionCheck() == JNI_TRUE) {

--- a/jni/include/jni_util.h
+++ b/jni/include/jni_util.h
@@ -1,0 +1,57 @@
+/*
+ *   Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+#ifndef OPENDISTRO_KNN_JNI_UTIL_H
+#define OPENDISTRO_KNN_JNI_UTIL_H
+
+#include <jni.h>
+#include <stdexcept>
+#include <new>
+
+void java_exception(JNIEnv* env, const char* type = "", const char* message = "") {
+    jclass newExcCls = env->FindClass(type);
+    if (newExcCls != nullptr) {
+        env->ThrowNew(newExcCls, message);
+    }
+    //If newExcCls isn't found, NoClassDefFoundError will be thrown
+}
+
+inline void has_exception_in_stack(JNIEnv* env)
+{
+    if (env->ExceptionCheck() == JNI_TRUE) {
+        throw std::runtime_error("Exception Occurred");
+    }
+}
+
+void catch_cpp_exception_and_throw_java(JNIEnv* env)
+{
+    try {
+        throw;
+    }
+    catch (const std::bad_alloc& rhs) {
+        java_exception(env, "java/io/IOException", rhs.what());
+    }
+    catch (const std::runtime_error& re) {
+        java_exception(env, "java/lang/Exception", re.what());
+    }
+    catch (const std::exception& e) {
+        java_exception(env, "java/lang/Exception", e.what());
+    }
+    catch (...) {
+        java_exception(env, "java/lang/Exception", "Unknown exception occurred");
+    }
+}
+
+#endif //OPENDISTRO_KNN_JNI_UTIL_H

--- a/jni/src/com_amazon_opendistroforelasticsearch_knn_index_v2011_KNNIndex.cpp
+++ b/jni/src/com_amazon_opendistroforelasticsearch_knn_index_v2011_KNNIndex.cpp
@@ -71,15 +71,9 @@ JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v201
         env->ReleaseIntArrayElements(ids, objectIds, 0);
         index = MethodFactoryRegistry<float>::Instance().CreateMethod(false, "hnsw", spaceTypeCppString, *space, dataset);
 
-        int paramsCount = env->GetArrayLength(algoParams);
-        vector<string> paramsList;
-        string paramString;
-        for (int i=0; i<paramsCount; i++) {
-            paramString = getStringJenv(env, (jstring)(env->GetObjectArrayElement(algoParams, i)));
-            paramsList.push_back(paramString);
-        }
-
+        auto paramsList = getVectorOfStrings(env, algoParams);
         string indexPathCppString = getStringJenv(env, indexPath);
+
         index->CreateIndex(AnyParams(paramsList));
         index->SaveIndex(indexPathCppString);
 
@@ -148,13 +142,7 @@ JNIEXPORT jlong JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v20
         indexWrapper->index->LoadIndex(indexPathCppString);
 
         // Parse and set query params
-        int paramsCount = env->GetArrayLength(algoParams);
-        vector<string> paramsList;
-        string paramString;
-        for (int i=0; i<paramsCount; i++) {
-            paramString = getStringJenv(env, (jstring)(env->GetObjectArrayElement(algoParams, i)));
-            paramsList.push_back(paramString);
-        }
+        auto paramsList = getVectorOfStrings(env, algoParams);
         indexWrapper->index->SetQueryTimeParams(AnyParams(paramsList));
 
         return (jlong) indexWrapper;

--- a/jni/src/com_amazon_opendistroforelasticsearch_knn_index_v2011_KNNIndex.cpp
+++ b/jni/src/com_amazon_opendistroforelasticsearch_knn_index_v2011_KNNIndex.cpp
@@ -58,7 +58,7 @@ JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v201
     int* objectIds = nullptr;
 
     try {
-        string spaceTypeCppString = getStringJenv(env, spaceType);
+        string spaceTypeCppString = GetStringJenv(env, spaceType);
         space = SpaceFactoryRegistry<float>::Instance().CreateSpace(spaceTypeCppString, AnyParams());
         objectIds = env->GetIntArrayElements(ids, nullptr);
         for (int i = 0; i < env->GetArrayLength(vectors); i++) {
@@ -71,8 +71,8 @@ JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v201
         env->ReleaseIntArrayElements(ids, objectIds, 0);
         index = MethodFactoryRegistry<float>::Instance().CreateMethod(false, "hnsw", spaceTypeCppString, *space, dataset);
 
-        auto paramsList = getVectorOfStrings(env, algoParams);
-        string indexPathCppString = getStringJenv(env, indexPath);
+        auto paramsList = GetVectorOfStrings(env, algoParams);
+        string indexPathCppString = GetStringJenv(env, indexPath);
 
         index->CreateIndex(AnyParams(paramsList));
         index->SaveIndex(indexPathCppString);
@@ -92,7 +92,7 @@ JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v201
         }
         delete index;
         delete space;
-        catch_cpp_exception_and_throw_java(env);
+        CatchCppExceptionAndThrowJava(env);
     }
 }
 
@@ -101,7 +101,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_amazon_opendistroforelasticsearch_knn_in
     try {
         auto *indexWrapper = reinterpret_cast<IndexWrapper*>(indexPointer);
         float* rawQueryvector = env->GetFloatArrayElements(queryVector, nullptr);
-        has_exception_in_stack(env);
+        HasExceptionInStack(env);
         std::unique_ptr<const Object> queryObject(new Object(-1, -1, env->GetArrayLength(queryVector)*sizeof(float), rawQueryvector));
         env->ReleaseFloatArrayElements(queryVector, rawQueryvector, 0);
 
@@ -112,12 +112,12 @@ JNIEXPORT jobjectArray JNICALL Java_com_amazon_opendistroforelasticsearch_knn_in
 
         jclass resultClass = env->FindClass("com/amazon/opendistroforelasticsearch/knn/index/KNNQueryResult");
         if (resultClass == nullptr) {
-            has_exception_in_stack(env);
+            HasExceptionInStack(env);
         }
 
         jmethodID allArgs = env->GetMethodID(resultClass, "<init>", "(IF)V");
         jobjectArray results = env->NewObjectArray(resultSize, resultClass, nullptr);
-        has_exception_in_stack(env);
+        HasExceptionInStack(env);
 
         for (int i = 0; i < resultSize; i++) {
             float distance = result->TopDistance();
@@ -126,7 +126,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_amazon_opendistroforelasticsearch_knn_in
         }
         return results;
     } catch(...) {
-        catch_cpp_exception_and_throw_java(env);
+        CatchCppExceptionAndThrowJava(env);
     }
     return nullptr;
 }
@@ -135,14 +135,14 @@ JNIEXPORT jlong JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v20
 {
     IndexWrapper *indexWrapper = nullptr;
     try {
-        string indexPathCppString = getStringJenv(env, indexPath);
-        string spaceTypeCppString = getStringJenv(env, spaceType);
+        string indexPathCppString = GetStringJenv(env, indexPath);
+        string spaceTypeCppString = GetStringJenv(env, spaceType);
 
         indexWrapper = new IndexWrapper(spaceTypeCppString);
         indexWrapper->index->LoadIndex(indexPathCppString);
 
         // Parse and set query params
-        auto paramsList = getVectorOfStrings(env, algoParams);
+        auto paramsList = GetVectorOfStrings(env, algoParams);
         indexWrapper->index->SetQueryTimeParams(AnyParams(paramsList));
 
         return (jlong) indexWrapper;
@@ -151,7 +151,7 @@ JNIEXPORT jlong JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v20
     // is the only known failure mode for init()).
     catch (...) {
         delete indexWrapper;
-        catch_cpp_exception_and_throw_java(env);
+        CatchCppExceptionAndThrowJava(env);
     }
     return NULL;
 }

--- a/jni/src/com_amazon_opendistroforelasticsearch_knn_index_v2011_KNNIndex.cpp
+++ b/jni/src/com_amazon_opendistroforelasticsearch_knn_index_v2011_KNNIndex.cpp
@@ -39,6 +39,7 @@ using similarity::Object;
 using similarity::KNNQuery;
 using similarity::KNNQueue;
 
+
 struct IndexWrapper {
   explicit IndexWrapper(const string& spaceType) {
     // Index gets constructed with a reference to data (see above) but is otherwise unused
@@ -49,6 +50,7 @@ struct IndexWrapper {
   std::unique_ptr<Space<float>> space;
   std::unique_ptr<Index<float>> index;
 };
+
 
 JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v2011_KNNIndex_saveIndex(JNIEnv* env, jclass cls, jintArray ids, jobjectArray vectors, jstring indexPath, jobjectArray algoParams, jstring spaceType)
 {
@@ -96,6 +98,7 @@ JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v201
     }
 }
 
+
 JNIEXPORT jobjectArray JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v2011_KNNIndex_queryIndex(JNIEnv* env, jclass cls, jlong indexPointer, jfloatArray queryVector, jint k)
 {
     try {
@@ -131,6 +134,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_amazon_opendistroforelasticsearch_knn_in
     return nullptr;
 }
 
+
 JNIEXPORT jlong JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v2011_KNNIndex_init(JNIEnv* env, jclass cls,  jstring indexPath, jobjectArray algoParams, jstring spaceType)
 {
     IndexWrapper *indexWrapper = nullptr;
@@ -156,11 +160,13 @@ JNIEXPORT jlong JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v20
     return NULL;
 }
 
+
 JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v2011_KNNIndex_gc(JNIEnv* env, jclass cls,  jlong indexPointer)
 {
     auto *indexWrapper = reinterpret_cast<IndexWrapper*>(indexPointer);
     delete indexWrapper;
 }
+
 
 JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v2011_KNNIndex_initLibrary(JNIEnv *, jclass)
 {

--- a/jni/src/com_amazon_opendistroforelasticsearch_knn_index_v2011_KNNIndex.cpp
+++ b/jni/src/com_amazon_opendistroforelasticsearch_knn_index_v2011_KNNIndex.cpp
@@ -60,7 +60,7 @@ JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v201
     int* objectIds = nullptr;
 
     try {
-        string spaceTypeCppString = GetStringJenv(env, spaceType);
+        string spaceTypeCppString = knn_jni::GetStringJenv(env, spaceType);
         space = SpaceFactoryRegistry<float>::Instance().CreateSpace(spaceTypeCppString, AnyParams());
         objectIds = env->GetIntArrayElements(ids, nullptr);
         for (int i = 0; i < env->GetArrayLength(vectors); i++) {
@@ -73,8 +73,8 @@ JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v201
         env->ReleaseIntArrayElements(ids, objectIds, 0);
         index = MethodFactoryRegistry<float>::Instance().CreateMethod(false, "hnsw", spaceTypeCppString, *space, dataset);
 
-        auto paramsList = GetVectorOfStrings(env, algoParams);
-        string indexPathCppString = GetStringJenv(env, indexPath);
+        auto paramsList = knn_jni::GetVectorOfStrings(env, algoParams);
+        string indexPathCppString = knn_jni::GetStringJenv(env, indexPath);
 
         index->CreateIndex(AnyParams(paramsList));
         index->SaveIndex(indexPathCppString);
@@ -94,7 +94,7 @@ JNIEXPORT void JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v201
         }
         delete index;
         delete space;
-        CatchCppExceptionAndThrowJava(env);
+        knn_jni::CatchCppExceptionAndThrowJava(env);
     }
 }
 
@@ -104,7 +104,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_amazon_opendistroforelasticsearch_knn_in
     try {
         auto *indexWrapper = reinterpret_cast<IndexWrapper*>(indexPointer);
         float* rawQueryvector = env->GetFloatArrayElements(queryVector, nullptr);
-        HasExceptionInStack(env);
+        knn_jni::HasExceptionInStack(env);
         std::unique_ptr<const Object> queryObject(new Object(-1, -1, env->GetArrayLength(queryVector)*sizeof(float), rawQueryvector));
         env->ReleaseFloatArrayElements(queryVector, rawQueryvector, 0);
 
@@ -115,12 +115,12 @@ JNIEXPORT jobjectArray JNICALL Java_com_amazon_opendistroforelasticsearch_knn_in
 
         jclass resultClass = env->FindClass("com/amazon/opendistroforelasticsearch/knn/index/KNNQueryResult");
         if (resultClass == nullptr) {
-            HasExceptionInStack(env);
+            knn_jni::HasExceptionInStack(env);
         }
 
         jmethodID allArgs = env->GetMethodID(resultClass, "<init>", "(IF)V");
         jobjectArray results = env->NewObjectArray(resultSize, resultClass, nullptr);
-        HasExceptionInStack(env);
+        knn_jni::HasExceptionInStack(env);
 
         for (int i = 0; i < resultSize; i++) {
             float distance = result->TopDistance();
@@ -129,7 +129,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_amazon_opendistroforelasticsearch_knn_in
         }
         return results;
     } catch(...) {
-        CatchCppExceptionAndThrowJava(env);
+        knn_jni::CatchCppExceptionAndThrowJava(env);
     }
     return nullptr;
 }
@@ -139,14 +139,14 @@ JNIEXPORT jlong JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v20
 {
     IndexWrapper *indexWrapper = nullptr;
     try {
-        string indexPathCppString = GetStringJenv(env, indexPath);
-        string spaceTypeCppString = GetStringJenv(env, spaceType);
+        string indexPathCppString = knn_jni::GetStringJenv(env, indexPath);
+        string spaceTypeCppString = knn_jni::GetStringJenv(env, spaceType);
 
         indexWrapper = new IndexWrapper(spaceTypeCppString);
         indexWrapper->index->LoadIndex(indexPathCppString);
 
         // Parse and set query params
-        auto paramsList = GetVectorOfStrings(env, algoParams);
+        auto paramsList = knn_jni::GetVectorOfStrings(env, algoParams);
         indexWrapper->index->SetQueryTimeParams(AnyParams(paramsList));
 
         return (jlong) indexWrapper;
@@ -155,7 +155,7 @@ JNIEXPORT jlong JNICALL Java_com_amazon_opendistroforelasticsearch_knn_index_v20
     // is the only known failure mode for init()).
     catch (...) {
         delete indexWrapper;
-        CatchCppExceptionAndThrowJava(env);
+        knn_jni::CatchCppExceptionAndThrowJava(env);
     }
     return NULL;
 }

--- a/jni/src/jni_util.cpp
+++ b/jni/src/jni_util.cpp
@@ -1,0 +1,76 @@
+/*
+ *   Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+#include "jni_util.h"
+
+#include <jni.h>
+#include <new>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+
+void ThrowJavaException(JNIEnv* env, const char* type, const char* message) {
+    jclass newExcCls = env->FindClass(type);
+    if (newExcCls != nullptr) {
+        env->ThrowNew(newExcCls, message);
+    }
+    // If newExcCls isn't found, NoClassDefFoundError will be thrown
+}
+
+
+void CatchCppExceptionAndThrowJava(JNIEnv* env)
+{
+    try {
+        throw;
+    }
+    catch (const std::bad_alloc& rhs) {
+        ThrowJavaException(env, "java/io/IOException", rhs.what());
+    }
+    catch (const std::runtime_error& re) {
+        ThrowJavaException(env, "java/lang/Exception", re.what());
+    }
+    catch (const std::exception& e) {
+        ThrowJavaException(env, "java/lang/Exception", e.what());
+    }
+    catch (...) {
+        ThrowJavaException(env, "java/lang/Exception", "Unknown exception occurred");
+    }
+}
+
+
+std::string GetStringJenv(JNIEnv * env, jstring javaString) {
+    const char *cString = env->GetStringUTFChars(javaString, nullptr);
+    if (cString == nullptr) {
+        HasExceptionInStack(env);
+    }
+    std::string cppString(cString);
+    env->ReleaseStringUTFChars(javaString, cString);
+    return cppString;
+}
+
+
+std::vector<std::string> GetVectorOfStrings(JNIEnv * env, jobjectArray javaStringsArray) {
+    int arraySize = env->GetArrayLength(javaStringsArray);
+    std::vector<std::string> stringVector;
+    std::string cppString;
+
+    for (int i=0; i < arraySize; i++) {
+        cppString = GetStringJenv(env, (jstring)(env->GetObjectArrayElement(javaStringsArray, i)));
+        stringVector.push_back(cppString);
+    }
+
+    return stringVector;
+}

--- a/jni/src/jni_util.cpp
+++ b/jni/src/jni_util.cpp
@@ -22,7 +22,7 @@
 #include <vector>
 
 
-void ThrowJavaException(JNIEnv* env, const char* type, const char* message) {
+void knn_jni::ThrowJavaException(JNIEnv* env, const char* type, const char* message) {
     jclass newExcCls = env->FindClass(type);
     if (newExcCls != nullptr) {
         env->ThrowNew(newExcCls, message);
@@ -31,7 +31,7 @@ void ThrowJavaException(JNIEnv* env, const char* type, const char* message) {
 }
 
 
-void CatchCppExceptionAndThrowJava(JNIEnv* env)
+void knn_jni::CatchCppExceptionAndThrowJava(JNIEnv* env)
 {
     try {
         throw;
@@ -51,7 +51,7 @@ void CatchCppExceptionAndThrowJava(JNIEnv* env)
 }
 
 
-std::string GetStringJenv(JNIEnv * env, jstring javaString) {
+std::string knn_jni::GetStringJenv(JNIEnv * env, jstring javaString) {
     const char *cString = env->GetStringUTFChars(javaString, nullptr);
     if (cString == nullptr) {
         HasExceptionInStack(env);
@@ -62,7 +62,7 @@ std::string GetStringJenv(JNIEnv * env, jstring javaString) {
 }
 
 
-std::vector<std::string> GetVectorOfStrings(JNIEnv * env, jobjectArray javaStringsArray) {
+std::vector<std::string> knn_jni::GetVectorOfStrings(JNIEnv * env, jobjectArray javaStringsArray) {
     int arraySize = env->GetArrayLength(javaStringsArray);
     std::vector<std::string> stringVector;
     std::string cppString;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR does a bit of refactoring of the jni library so that code can be re-used when adding support for other libraries. It takes out common code related to exception handling and JNI translations into a separate jni_util module.

Additionally, it cleans up a few other things such as naming, style, exception checking, clang-tidy warnings. For naming of utility functions, I decided to follow Google's conventions here: https://google.github.io/styleguide/cppguide.html#Function_Names. Overall, this change may slightly improve performance, but not significantly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
