### PR TITLE
Move constants out of index folder into common

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/common/KNNConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/common/KNNConstants.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *   Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").
  *   You may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-package com.amazon.opendistroforelasticsearch.knn.index.util;
+package com.amazon.opendistroforelasticsearch.knn.common;
 
 public class KNNConstants {
     public static final String SPACE_TYPE = "spaceType";

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNVectorFieldMapper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNVectorFieldMapper.java
@@ -15,7 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.knn.index;
 
-import com.amazon.opendistroforelasticsearch.knn.index.util.KNNConstants;
+import com.amazon.opendistroforelasticsearch.knn.common.KNNConstants;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -35,7 +35,7 @@ import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.IOUtils;
 import com.amazon.opendistroforelasticsearch.knn.index.KNNSettings;
 import com.amazon.opendistroforelasticsearch.knn.index.KNNVectorFieldMapper;
-import com.amazon.opendistroforelasticsearch.knn.index.util.KNNConstants;
+import com.amazon.opendistroforelasticsearch.knn.common.KNNConstants;
 import com.amazon.opendistroforelasticsearch.knn.index.util.NmsLibVersion;
 import com.amazon.opendistroforelasticsearch.knn.index.v2011.KNNIndex;
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpaceFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpaceFactory.java
@@ -16,7 +16,7 @@
 
 package com.amazon.opendistroforelasticsearch.knn.plugin.script;
 
-import com.amazon.opendistroforelasticsearch.knn.index.util.KNNConstants;
+import com.amazon.opendistroforelasticsearch.knn.common.KNNConstants;
 import com.amazon.opendistroforelasticsearch.knn.plugin.stats.KNNCounter;
 import org.elasticsearch.index.mapper.MappedFieldType;
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNVectorFieldMapperTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNVectorFieldMapperTests.java
@@ -16,7 +16,7 @@
 package com.amazon.opendistroforelasticsearch.knn.index;
 
 import com.amazon.opendistroforelasticsearch.knn.KNNTestCase;
-import com.amazon.opendistroforelasticsearch.knn.index.util.KNNConstants;
+import com.amazon.opendistroforelasticsearch.knn.common.KNNConstants;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.IndexScopedSettings;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/action/RestKNNStatsHandlerIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/action/RestKNNStatsHandlerIT.java
@@ -17,7 +17,7 @@ package com.amazon.opendistroforelasticsearch.knn.plugin.action;
 
 import com.amazon.opendistroforelasticsearch.knn.KNNRestTestCase;
 import com.amazon.opendistroforelasticsearch.knn.index.KNNQueryBuilder;
-import com.amazon.opendistroforelasticsearch.knn.index.util.KNNConstants;
+import com.amazon.opendistroforelasticsearch.knn.common.KNNConstants;
 import com.amazon.opendistroforelasticsearch.knn.plugin.stats.KNNStats;
 
 import com.amazon.opendistroforelasticsearch.knn.plugin.stats.StatNames;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpaceFactoryTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpaceFactoryTests.java
@@ -17,7 +17,7 @@ package com.amazon.opendistroforelasticsearch.knn.plugin.script;
 
 import com.amazon.opendistroforelasticsearch.knn.KNNTestCase;
 import com.amazon.opendistroforelasticsearch.knn.index.KNNVectorFieldMapper;
-import com.amazon.opendistroforelasticsearch.knn.index.util.KNNConstants;
+import com.amazon.opendistroforelasticsearch.knn.common.KNNConstants;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 
 import java.util.ArrayList;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScriptScoringIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScriptScoringIT.java
@@ -17,7 +17,7 @@ package com.amazon.opendistroforelasticsearch.knn.plugin.script;
 
 import com.amazon.opendistroforelasticsearch.knn.KNNRestTestCase;
 import com.amazon.opendistroforelasticsearch.knn.KNNResult;
-import com.amazon.opendistroforelasticsearch.knn.index.util.KNNConstants;
+import com.amazon.opendistroforelasticsearch.knn.common.KNNConstants;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Small refactor to move KNNConstants into common and out of index directory. Doing this because KNNConstants is being used for scripting as well as ann functionality.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
