### PR TITLE
Expose inner_product space type, refactoring SpaceTypes.

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/common/KNNConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/common/KNNConstants.java
@@ -26,6 +26,6 @@ public class KNNConstants {
     public static final String LINF = "linf";
     public static final String COSINESIMIL = "cosinesimil";
     public static final String HAMMING_BIT = "hammingbit";
-    public static final String INNER_PROD = "inner_product";
+    public static final String INNER_PROD = "innerproduct";
     public static final String DIMENSION = "dimension";
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/common/KNNConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/common/KNNConstants.java
@@ -26,6 +26,6 @@ public class KNNConstants {
     public static final String LINF = "linf";
     public static final String COSINESIMIL = "cosinesimil";
     public static final String HAMMING_BIT = "hammingbit";
-    public static final String NEGDOTPROD = "negdotprod";
+    public static final String INNER_PROD = "inner_product";
     public static final String DIMENSION = "dimension";
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNIndexCache.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNIndexCache.java
@@ -304,7 +304,7 @@ public class KNNIndexCache implements Closeable {
         // the entry
         fileWatcher.init();
 
-        final KNNIndex knnIndex = KNNIndex.loadIndex(indexPathUrl, getQueryParams(indexName), KNNSettings.getSpaceType(indexName));
+        final KNNIndex knnIndex = KNNIndex.loadIndex(indexPathUrl, getQueryParams(indexName), SpaceTypes.getValueByKey(KNNSettings.getSpaceType(indexName)));
 
         // TODO verify that this is safe - ideally we'd explicitly ensure that the FileWatcher is only checked
         // after the guava cache has finished loading the key to avoid a race condition where the watcher

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNSettings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNSettings.java
@@ -381,11 +381,11 @@ public class KNNSettings {
     /**
      *
      * @param index Name of the index
-     * @return spaceType value
+     * @return spaceType name in KNN plugin
      */
     public static String getSpaceType(String index) {
         return KNNSettings.state().clusterService.state().getMetadata()
-            .index(index).getSettings().get(KNN_SPACE_TYPE, SpaceTypes.l2.getValue());
+            .index(index).getSettings().get(KNN_SPACE_TYPE, SpaceTypes.l2.getKey());
     }
 
     public static int getIndexSettingValue(String index, String settingName, int defaultValue) {
@@ -400,10 +400,8 @@ public class KNNSettings {
 
     static class SpaceTypeValidator implements Setting.Validator<String> {
 
-        private Set<String> types = SpaceTypes.getValues();
-
         @Override public void validate(String value) {
-            if (value == null || !types.contains(value.toLowerCase())){
+            if (value == null || !SpaceTypes.contains(value.toLowerCase())){
                 throw new InvalidParameterException(String.format("Unsupported space type: %s", value));
             }
         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/SpaceTypes.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/SpaceTypes.java
@@ -15,41 +15,52 @@
 
 package com.amazon.opendistroforelasticsearch.knn.index;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
  * Enum contains space types for k-NN similarity search
  */
 public enum SpaceTypes {
-  l2("l2"),
-  cosinesimil("cosinesimil"),
-  l1("l1"),
-  linf("linf"),
-  negdotprod("negdotprod");
+  l2("l2", "l2"),
+  cosinesimil("cosinesimil", "cosinesimil"),
+  l1("l1", "l1"),
+  linf("linf", "linf"),
+  inner_product("inner_product", "negdotprod");
 
-  private String value;
+  private static final Map<String, String> TRANSLATION = new HashMap<>();
 
-  SpaceTypes(String value) { this.value = value; }
+  private final String key;
+  private final String value;
+
+  static {
+    for (SpaceTypes spaceType : values()) {
+      TRANSLATION.put(spaceType.key, spaceType.value);
+    }
+  }
+
+  public static boolean contains(final String name) { return TRANSLATION.containsKey(name); }
+
+  public static String getValueByKey(final String name) { return TRANSLATION.get(name); }
+
+  SpaceTypes(String key, String value) {
+    this.key = key;
+    this.value = value;
+  }
 
   /**
-   * Get space type
+   * Get space type name in KNN plugin
+   *
+   * @return name
+   */
+  public String getKey() { return key; }
+
+  /**
+   * Get space type name in nmslib
    *
    * @return name
    */
   public String getValue() { return value; }
-
-  /**
-   * Get all space types
-   *
-   * @return set of all stat names
-   */
-  public static Set<String> getValues() {
-    Set<String> values = new HashSet<>();
-
-    for (SpaceTypes spaceType : SpaceTypes.values()) {
-      values.add(spaceType.getValue());
-    }
-    return values;
-  }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/SpaceTypes.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/SpaceTypes.java
@@ -30,7 +30,7 @@ public enum SpaceTypes {
   cosinesimil("cosinesimil", "cosinesimil"),
   l1("l1", "l1"),
   linf("linf", "linf"),
-  inner_product("inner_product", "negdotprod");
+  inner_product("innerproduct", "negdotprod");
 
   private static final Map<String, String> TRANSLATION = new HashMap<>();
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/SpaceTypes.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/SpaceTypes.java
@@ -21,7 +21,9 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Enum contains space types for k-NN similarity search
+ * Enum contains space type key-value pairs for k-NN similarity search.
+ * key represents the space type name exposed to user;
+ * value represents the internal space type name used in nmslib.
  */
 public enum SpaceTypes {
   l2("l2", "l2"),

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -98,7 +98,7 @@ class KNN80DocValuesConsumer extends DocValuesConsumer implements Closeable {
             // Pass the path for the nms library to save the file
             String tempIndexPath = indexPath + TEMP_SUFFIX;
             Map<String, String> fieldAttributes = field.attributes();
-            String spaceType = fieldAttributes.getOrDefault(KNNConstants.SPACE_TYPE, SpaceTypes.l2.getValue());
+            String spaceType = SpaceTypes.getValueByKey(fieldAttributes.getOrDefault(KNNConstants.SPACE_TYPE, SpaceTypes.l2.getKey()));
             String[] algoParams = getKNNIndexParams(fieldAttributes);
             AccessController.doPrivileged(
                     new PrivilegedAction<Void>() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpace.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpace.java
@@ -214,14 +214,14 @@ public interface KNNScoringSpace {
         BiFunction<float[], float[], Float> scoringMethod;
 
         /**
-         * Constructor for inner_product scoring space. inner_product scoring space expects values to be of type float[].
+         * Constructor for innerproduct scoring space. innerproduct scoring space expects values to be of type float[].
          *
          * @param query Query object that, along with the doc values, will be used to compute L-inf score
          * @param fieldType FieldType for the doc values that will be used
          */
         public InnerProd(Object query, MappedFieldType fieldType) {
             if (!isKNNVectorFieldType(fieldType)) {
-                throw new IllegalArgumentException("Incompatible field_type for inner_product space. The field type must " +
+                throw new IllegalArgumentException("Incompatible field_type for innerproduct space. The field type must " +
                         "be knn_vector.");
             }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpace.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpace.java
@@ -227,7 +227,7 @@ public interface KNNScoringSpace {
 
             this.processedQuery = parseToFloatArray(query,
                     ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getDimension());
-            this.scoringMethod = (float[] q, float[] v) -> KNNWeight.normalizeScore(-KNNScoringUtil.innerProd(q, v));
+            this.scoringMethod = (float[] q, float[] v) -> KNNWeight.normalizeScore(-KNNScoringUtil.innerProduct(q, v));
         }
 
         @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpace.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpace.java
@@ -208,26 +208,26 @@ public interface KNNScoringSpace {
         }
     }
 
-    class NegDotProd implements KNNScoringSpace {
+    class InnerProd implements KNNScoringSpace {
 
         float[] processedQuery;
         BiFunction<float[], float[], Float> scoringMethod;
 
         /**
-         * Constructor for negative dot product (negdotprod) scoring space. negdotprod scoring space expects values to be of type float[].
+         * Constructor for inner_product scoring space. inner_product scoring space expects values to be of type float[].
          *
          * @param query Query object that, along with the doc values, will be used to compute L-inf score
          * @param fieldType FieldType for the doc values that will be used
          */
-        public NegDotProd(Object query, MappedFieldType fieldType) {
+        public InnerProd(Object query, MappedFieldType fieldType) {
             if (!isKNNVectorFieldType(fieldType)) {
-                throw new IllegalArgumentException("Incompatible field_type for negdotprod space. The field type must " +
+                throw new IllegalArgumentException("Incompatible field_type for inner_product space. The field type must " +
                         "be knn_vector.");
             }
 
             this.processedQuery = parseToFloatArray(query,
                     ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getDimension());
-            this.scoringMethod = (float[] q, float[] v) -> KNNWeight.score(KNNScoringUtil.negdotprod(q, v));
+            this.scoringMethod = (float[] q, float[] v) -> KNNWeight.score(-KNNScoringUtil.innerProd(q, v));
         }
 
         @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpaceFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpaceFactory.java
@@ -40,7 +40,7 @@ public class KNNScoringSpaceFactory {
         }
 
         if (KNNConstants.INNER_PROD.equalsIgnoreCase(spaceType)) {
-            return new KNNScoringSpace.NegDotProd(query, mappedFieldType);
+            return new KNNScoringSpace.InnerProd(query, mappedFieldType);
         }
 
         if (KNNConstants.COSINESIMIL.equalsIgnoreCase(spaceType)) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpaceFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpaceFactory.java
@@ -39,7 +39,7 @@ public class KNNScoringSpaceFactory {
             return new KNNScoringSpace.LInf(query, mappedFieldType);
         }
 
-        if (KNNConstants.NEGDOTPROD.equalsIgnoreCase(spaceType)) {
+        if (KNNConstants.INNER_PROD.equalsIgnoreCase(spaceType)) {
             return new KNNScoringSpace.NegDotProd(query, mappedFieldType);
         }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringUtil.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringUtil.java
@@ -293,7 +293,7 @@ public class KNNScoringUtil {
      * @param inputVector input vector
      * @return dot product score
      */
-    public static float innerProd(float[] queryVector, float[] inputVector) {
+    public static float innerProduct(float[] queryVector, float[] inputVector) {
         requireEqualDimension(queryVector, inputVector);
         float distance = 0;
         for (int i = 0; i < inputVector.length; i++) {
@@ -307,7 +307,7 @@ public class KNNScoringUtil {
      * and document vectors
      * Example
      *  "script": {
-     *         "source": "float x = innerProd([1.0f, 1.0f], doc['%s']); return x&gt;=0? 2-(1/(x+1)):1/(1-x);",
+     *         "source": "float x = innerProduct([1.0f, 1.0f], doc['%s']); return x&gt;=0? 2-(1/(x+1)):1/(1-x);",
      *         "params": {
      *           "query_vector": [1, 2, 3.4],
      *           "field": "my_dense_vector"
@@ -318,7 +318,7 @@ public class KNNScoringUtil {
      * @param docValues   script doc values
      * @return inner product score
      */
-    public static float innerProd(List<Number> queryVector, KNNVectorScriptDocValues docValues) {
-        return innerProd(toFloat(queryVector), docValues.getValue());
+    public static float innerProduct(List<Number> queryVector, KNNVectorScriptDocValues docValues) {
+        return innerProduct(toFloat(queryVector), docValues.getValue());
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringUtil.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringUtil.java
@@ -286,28 +286,28 @@ public class KNNScoringUtil {
     }
 
     /**
-     * This method calculates negative dot product distance between query vector
+     * This method calculates dot product distance between query vector
      * and input vector
      *
      * @param queryVector query vector
      * @param inputVector input vector
-     * @return negdotprod score
+     * @return dot product score
      */
-    public static float negdotprod(float[] queryVector, float[] inputVector) {
+    public static float innerProd(float[] queryVector, float[] inputVector) {
         requireEqualDimension(queryVector, inputVector);
         float distance = 0;
         for (int i = 0; i < inputVector.length; i++) {
-            distance -= queryVector[i] * inputVector[i];
+            distance += queryVector[i] * inputVector[i];
         }
         return distance;
     }
 
     /**
-     * Whitelisted negdotprod method for users to calculate negative dot product distance between query vector
+     * Whitelisted innerProd method for users to calculate inner product distance between query vector
      * and document vectors
      * Example
      *  "script": {
-     *         "source": "float x = negdotprod([1.0f, 1.0f], doc['%s']); return x&gt;=0? 1/(1+x):2+1/(x-1);",
+     *         "source": "float x = innerProd([1.0f, 1.0f], doc['%s']); return x&gt;=0? 2-(1/(x+1)):1/(1-x);",
      *         "params": {
      *           "query_vector": [1, 2, 3.4],
      *           "field": "my_dense_vector"
@@ -316,9 +316,9 @@ public class KNNScoringUtil {
      *
      * @param queryVector query vector
      * @param docValues   script doc values
-     * @return negdotprod score
+     * @return inner product score
      */
-    public static float negdotprod(List<Number> queryVector, KNNVectorScriptDocValues docValues) {
-        return negdotprod(toFloat(queryVector), docValues.getValue());
+    public static float innerProd(List<Number> queryVector, KNNVectorScriptDocValues docValues) {
+        return innerProd(toFloat(queryVector), docValues.getValue());
     }
 }

--- a/src/main/resources/com/amazon/opendistroforelasticsearch/knn/plugin/script/knn_whitelist.txt
+++ b/src/main/resources/com/amazon/opendistroforelasticsearch/knn/plugin/script/knn_whitelist.txt
@@ -19,7 +19,7 @@ static_import {
   float l2Squared(List, com.amazon.opendistroforelasticsearch.knn.index.KNNVectorScriptDocValues) from_class com.amazon.opendistroforelasticsearch.knn.plugin.script.KNNScoringUtil
   float lInfNorm(List, com.amazon.opendistroforelasticsearch.knn.index.KNNVectorScriptDocValues) from_class com.amazon.opendistroforelasticsearch.knn.plugin.script.KNNScoringUtil
   float l1Norm(List, com.amazon.opendistroforelasticsearch.knn.index.KNNVectorScriptDocValues) from_class com.amazon.opendistroforelasticsearch.knn.plugin.script.KNNScoringUtil
-  float innerProd(List, com.amazon.opendistroforelasticsearch.knn.index.KNNVectorScriptDocValues) from_class com.amazon.opendistroforelasticsearch.knn.plugin.script.KNNScoringUtil
+  float innerProduct(List, com.amazon.opendistroforelasticsearch.knn.index.KNNVectorScriptDocValues) from_class com.amazon.opendistroforelasticsearch.knn.plugin.script.KNNScoringUtil
   float cosineSimilarity(List, com.amazon.opendistroforelasticsearch.knn.index.KNNVectorScriptDocValues) from_class com.amazon.opendistroforelasticsearch.knn.plugin.script.KNNScoringUtil
   float cosineSimilarity(List, com.amazon.opendistroforelasticsearch.knn.index.KNNVectorScriptDocValues, Number) from_class com.amazon.opendistroforelasticsearch.knn.plugin.script.KNNScoringUtil
 }

--- a/src/main/resources/com/amazon/opendistroforelasticsearch/knn/plugin/script/knn_whitelist.txt
+++ b/src/main/resources/com/amazon/opendistroforelasticsearch/knn/plugin/script/knn_whitelist.txt
@@ -19,7 +19,7 @@ static_import {
   float l2Squared(List, com.amazon.opendistroforelasticsearch.knn.index.KNNVectorScriptDocValues) from_class com.amazon.opendistroforelasticsearch.knn.plugin.script.KNNScoringUtil
   float lInfNorm(List, com.amazon.opendistroforelasticsearch.knn.index.KNNVectorScriptDocValues) from_class com.amazon.opendistroforelasticsearch.knn.plugin.script.KNNScoringUtil
   float l1Norm(List, com.amazon.opendistroforelasticsearch.knn.index.KNNVectorScriptDocValues) from_class com.amazon.opendistroforelasticsearch.knn.plugin.script.KNNScoringUtil
-  float negdotprod(List, com.amazon.opendistroforelasticsearch.knn.index.KNNVectorScriptDocValues) from_class com.amazon.opendistroforelasticsearch.knn.plugin.script.KNNScoringUtil
+  float innerProd(List, com.amazon.opendistroforelasticsearch.knn.index.KNNVectorScriptDocValues) from_class com.amazon.opendistroforelasticsearch.knn.plugin.script.KNNScoringUtil
   float cosineSimilarity(List, com.amazon.opendistroforelasticsearch.knn.index.KNNVectorScriptDocValues) from_class com.amazon.opendistroforelasticsearch.knn.plugin.script.KNNScoringUtil
   float cosineSimilarity(List, com.amazon.opendistroforelasticsearch.knn.index.KNNVectorScriptDocValues, Number) from_class com.amazon.opendistroforelasticsearch.knn.plugin.script.KNNScoringUtil
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNJNITests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNJNITests.java
@@ -331,7 +331,7 @@ public class KNNJNITests extends KNNTestCase {
         dir.close();
     }
 
-    public void testAddAndQueryHnswIndexNegDotProd() throws Exception {
+    public void testAddAndQueryHnswIndexInnerProd() throws Exception {
         int[] docs = {0, 1, 2};
 
         float[][] vectors = {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNJNITests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNJNITests.java
@@ -349,7 +349,7 @@ public class KNNJNITests extends KNNTestCase {
         AccessController.doPrivileged(
                 new PrivilegedAction<Void>() {
                     public Void run() {
-                        KNNIndex.saveIndex(docs, vectors, indexPath, algoParams, SpaceTypes.negdotprod.getValue());
+                        KNNIndex.saveIndex(docs, vectors, indexPath, algoParams, SpaceTypes.inner_product.getValue());
                         return null;
                     }
                 }
@@ -360,7 +360,7 @@ public class KNNJNITests extends KNNTestCase {
         float[] queryVector = {2.0f, -2.0f};
         String[] algoQueryParams = {"efSearch=20"};
 
-        final KNNIndex knnIndex = KNNIndex.loadIndex(indexPath, algoQueryParams, SpaceTypes.negdotprod.getValue());
+        final KNNIndex knnIndex = KNNIndex.loadIndex(indexPath, algoQueryParams, SpaceTypes.inner_product.getValue());
         final KNNQueryResult[] results = knnIndex.queryIndex(queryVector, 30);
 
         Map<Integer, Float> scores = Arrays.stream(results).collect(

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpaceFactoryTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpaceFactoryTests.java
@@ -39,7 +39,7 @@ public class KNNScoringSpaceFactoryTests extends KNNTestCase {
                 instanceof KNNScoringSpace.L2);
         assertTrue(KNNScoringSpaceFactory.create(KNNConstants.COSINESIMIL, floatQueryObject, knnVectorFieldType)
                 instanceof KNNScoringSpace.CosineSimilarity);
-        assertTrue(KNNScoringSpaceFactory.create(KNNConstants.NEGDOTPROD, floatQueryObject, knnVectorFieldType)
+        assertTrue(KNNScoringSpaceFactory.create(KNNConstants.INNER_PROD, floatQueryObject, knnVectorFieldType)
                 instanceof KNNScoringSpace.NegDotProd);
         assertTrue(KNNScoringSpaceFactory.create(KNNConstants.HAMMING_BIT, longQueryObject, numberFieldType)
                 instanceof KNNScoringSpace.HammingBit);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpaceFactoryTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpaceFactoryTests.java
@@ -40,7 +40,7 @@ public class KNNScoringSpaceFactoryTests extends KNNTestCase {
         assertTrue(KNNScoringSpaceFactory.create(KNNConstants.COSINESIMIL, floatQueryObject, knnVectorFieldType)
                 instanceof KNNScoringSpace.CosineSimilarity);
         assertTrue(KNNScoringSpaceFactory.create(KNNConstants.INNER_PROD, floatQueryObject, knnVectorFieldType)
-                instanceof KNNScoringSpace.NegDotProd);
+                instanceof KNNScoringSpace.InnerProd);
         assertTrue(KNNScoringSpaceFactory.create(KNNConstants.HAMMING_BIT, longQueryObject, numberFieldType)
                 instanceof KNNScoringSpace.HammingBit);
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpaceTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpaceTests.java
@@ -64,22 +64,22 @@ public class KNNScoringSpaceTests extends KNNTestCase {
                 new KNNScoringSpace.CosineSimilarity(arrayListQueryObject, invalidFieldType));
     }
 
-    public void testNegDotProdSimilarity() {
+    public void testInnerProdSimilarity() {
         float[] arrayFloat = new float[]{1.0f, 2.0f, 3.0f};
         List<Double> arrayListQueryObject = new ArrayList<>(Arrays.asList(1.0, 2.0, 3.0));
         float[] arrayFloat2 = new float[]{1.0f, 1.0f, 1.0f};
 
         KNNVectorFieldMapper.KNNVectorFieldType fieldType = new KNNVectorFieldMapper.KNNVectorFieldType("test",
                 Collections.emptyMap(), 3);
-        KNNScoringSpace.NegDotProd negDotProd =
-                new KNNScoringSpace.NegDotProd(arrayListQueryObject, fieldType);
+        KNNScoringSpace.InnerProd innerProd =
+                new KNNScoringSpace.InnerProd(arrayListQueryObject, fieldType);
 
-        assertEquals(1.857F, negDotProd.scoringMethod.apply(arrayFloat2, arrayFloat), 0.001F);
+        assertEquals(1.857F, innerProd.scoringMethod.apply(arrayFloat2, arrayFloat), 0.001F);
 
         NumberFieldMapper.NumberFieldType invalidFieldType = new NumberFieldMapper.NumberFieldType("field",
                 NumberFieldMapper.NumberType.INTEGER);
         expectThrows(IllegalArgumentException.class, () ->
-                new KNNScoringSpace.NegDotProd(arrayListQueryObject, invalidFieldType));
+                new KNNScoringSpace.InnerProd(arrayListQueryObject, invalidFieldType));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScriptScoringIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScriptScoringIT.java
@@ -671,7 +671,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
          *   params": {
          *       "field": "my_dense_vector",
          *       "query_value": [1.0, 1.0],
-         *       "space_type": "inner_product",
+         *       "space_type": "innerproduct",
          *      }
          */
         float[] queryVector = {1.0f, 1.0f};

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScriptScoringIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScriptScoringIT.java
@@ -644,7 +644,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         assertArrayEquals(correctScores2, scores2, 0.001);
     }
 
-    public void testKNNNegDotProdScriptScore() throws Exception {
+    public void testKNNInnerProdScriptScore() throws Exception {
         /*
          * Create knn index and populate data
          */

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScriptScoringIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScriptScoringIT.java
@@ -671,13 +671,13 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
          *   params": {
          *       "field": "my_dense_vector",
          *       "query_value": [1.0, 1.0],
-         *       "space_type": "negdotprod",
+         *       "space_type": "inner_product",
          *      }
          */
         float[] queryVector = {1.0f, 1.0f};
         params.put("field", FIELD_NAME);
         params.put("query_value", queryVector);
-        params.put("space_type", KNNConstants.NEGDOTPROD);
+        params.put("space_type", KNNConstants.INNER_PROD);
         Request request = constructKNNScriptQueryRequest(INDEX_NAME, qb, params);
         Response response = client().performRequest(request);
         assertEquals(request.getEndpoint() + ": failed", RestStatus.OK,

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/PainlessScriptScoringIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/PainlessScriptScoringIT.java
@@ -373,7 +373,7 @@ public class PainlessScriptScoringIT extends KNNRestTestCase {
 
     public void testInnerProdScriptScoreFails() throws Exception {
         String source = String.format(
-                "float x = innerProd([1.0f, 1.0f], doc['%s']); return x >= 0? 2-1/(x+1):1/(1-x);", FIELD_NAME);
+                "float x = innerProduct([1.0f, 1.0f], doc['%s']); return x >= 0? 2-1/(x+1):1/(1-x);", FIELD_NAME);
         Request request = buildPainlessScriptRequest(source, 3, getInnerProdTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
         expectThrows(ResponseException.class, () -> client().performRequest(request));
@@ -383,7 +383,7 @@ public class PainlessScriptScoringIT extends KNNRestTestCase {
     public void testInnerProdScriptScore() throws Exception {
 
         String source = String.format(
-                "float x = innerProd([1.0f, 1.0f], doc['%s']); return x >= 0? 2-1/(x+1):1/(1-x);", FIELD_NAME);
+                "float x = innerProduct([1.0f, 1.0f], doc['%s']); return x >= 0? 2-1/(x+1):1/(1-x);", FIELD_NAME);
         Request request = buildPainlessScriptRequest(source, 3, getInnerProdTestData());
 
         Response response = client().performRequest(request);
@@ -407,7 +407,7 @@ public class PainlessScriptScoringIT extends KNNRestTestCase {
                 "if (doc['%s'].size() == 0) " +
                         "{ return 0; } " +
                         "else " +
-                        "{ float x = innerProd([1.0f, 1.0f], doc['%s']); return x >= 0? 2-1/(x+1):1/(1-x); }",
+                        "{ float x = innerProduct([1.0f, 1.0f], doc['%s']); return x >= 0? 2-1/(x+1):1/(1-x); }",
                 FIELD_NAME, FIELD_NAME);
         Request request = buildPainlessScriptRequest(source, 3, getInnerProdTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/PainlessScriptScoringIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/PainlessScriptScoringIT.java
@@ -99,7 +99,7 @@ public class PainlessScriptScoringIT extends KNNRestTestCase {
         return data;
     }
 
-    private Map<String, Float[]> getNegDotProdTestData() {
+    private Map<String, Float[]> getInnerProdTestData() {
         Map<String, Float[]> data = new HashMap<>();
         data.put("1", new Float[]{-2.0f, -2.0f});
         data.put("2", new Float[]{1.0f, 1.0f});
@@ -371,20 +371,20 @@ public class PainlessScriptScoringIT extends KNNRestTestCase {
         deleteKNNIndex(INDEX_NAME);
     }
 
-    public void testNegDotProdScriptScoreFails() throws Exception {
+    public void testInnerProdScriptScoreFails() throws Exception {
         String source = String.format(
-                "float x = negdotprod([1.0f, 1.0f], doc['%s']); return x >= 0? 1/(1+x):2+1/(x-1);", FIELD_NAME);
-        Request request = buildPainlessScriptRequest(source, 3, getNegDotProdTestData());
+                "float x = innerProd([1.0f, 1.0f], doc['%s']); return x >= 0? 2-1/(x+1):1/(1-x);", FIELD_NAME);
+        Request request = buildPainlessScriptRequest(source, 3, getInnerProdTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
         expectThrows(ResponseException.class, () -> client().performRequest(request));
         deleteKNNIndex(INDEX_NAME);
     }
 
-    public void testNegDotProdScriptScore() throws Exception {
+    public void testInnerProdScriptScore() throws Exception {
 
         String source = String.format(
-                "float x = negdotprod([1.0f, 1.0f], doc['%s']); return x >= 0? 1/(1+x):2+1/(x-1);", FIELD_NAME);
-        Request request = buildPainlessScriptRequest(source, 3, getNegDotProdTestData());
+                "float x = innerProd([1.0f, 1.0f], doc['%s']); return x >= 0? 2-1/(x+1):1/(1-x);", FIELD_NAME);
+        Request request = buildPainlessScriptRequest(source, 3, getInnerProdTestData());
 
         Response response = client().performRequest(request);
         assertEquals(request.getEndpoint() + ": failed", RestStatus.OK,
@@ -401,15 +401,15 @@ public class PainlessScriptScoringIT extends KNNRestTestCase {
         deleteKNNIndex(INDEX_NAME);
     }
 
-    public void testNegDotProdScriptScoreWithNumericField() throws Exception {
+    public void testInnerProdScriptScoreWithNumericField() throws Exception {
 
         String source = String.format(
                 "if (doc['%s'].size() == 0) " +
                         "{ return 0; } " +
                         "else " +
-                        "{ float x = negdotprod([1.0f, 1.0f], doc['%s']); return x >= 0? 1/(1+x):2+1/(x-1); }",
+                        "{ float x = innerProd([1.0f, 1.0f], doc['%s']); return x >= 0? 2-1/(x+1):1/(1-x); }",
                 FIELD_NAME, FIELD_NAME);
-        Request request = buildPainlessScriptRequest(source, 3, getNegDotProdTestData());
+        Request request = buildPainlessScriptRequest(source, 3, getInnerProdTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
         Response response = client().performRequest(request);
         assertEquals(request.getEndpoint() + ": failed", RestStatus.OK,


### PR DESCRIPTION
*Issue #, if available:*
#114 #327 

*Description of changes:*
This PR
(1) Refactors SpaceTypes to translate between names in the plugin and param value in nmslib
(1) Exposes inner_product as space_type in ANN, custom scoring
(2) Exposes innerProd in painless.

Note: In painless, I identifies inner_product just as dot product (= - negdotprod) which might be more intuitive for user. Let me know what you think.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
