### PR TITLE
Add dimension validation to ANN QueryBuilder

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNQueryBuilder.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNQueryBuilder.java
@@ -192,14 +192,21 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
 
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
+        if (((KNNVectorFieldMapper.KNNVectorFieldType) context.fieldMapper(this.fieldName)).getDimension()
+                != vector.length) {
+            throw new IllegalArgumentException("Invalid vector query vector: " + vector.length +
+                    ". Dimension should be: " +
+                    ((KNNVectorFieldMapper.KNNVectorFieldType) context.fieldMapper(this.fieldName)).dimension);
+        }
+
         return new KNNQuery(this.fieldName, vector, k, context.index().getName());
     }
 
     @Override
     protected boolean doEquals(KNNQueryBuilder other) {
         return Objects.equals(fieldName, other.fieldName) &&
-                       Objects.equals(vector, other.vector) &&
-                       Objects.equals(k, other.k);
+                Objects.equals(vector, other.vector) &&
+                Objects.equals(k, other.k);
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNQueryBuilder.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNQueryBuilder.java
@@ -205,8 +205,8 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
     @Override
     protected boolean doEquals(KNNQueryBuilder other) {
         return Objects.equals(fieldName, other.fieldName) &&
-                Objects.equals(vector, other.vector) &&
-                Objects.equals(k, other.k);
+                       Objects.equals(vector, other.vector) &&
+                       Objects.equals(k, other.k);
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNQueryBuilder.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNQueryBuilder.java
@@ -198,7 +198,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         MappedFieldType mappedFieldType = context.fieldMapper(this.fieldName);
 
         if (!(mappedFieldType instanceof KNNVectorFieldMapper.KNNVectorFieldType)) {
-            throw new IllegalArgumentException("Field '" + this.fieldName + "' is not knn type.");
+            throw new IllegalArgumentException("Field '" + this.fieldName + "' is not knn_vector type.");
         }
 
         int dimension = ((KNNVectorFieldMapper.KNNVectorFieldType) mappedFieldType).getDimension();

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNQueryBuilderTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNQueryBuilderTests.java
@@ -20,7 +20,10 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.query.QueryShardContext;
+
+import java.io.IOException;
 
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -109,6 +112,17 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
         expectThrows(IllegalArgumentException.class, () -> knnQueryBuilder.doToQuery(mockQueryShardContext));
         when(mockKNNVectorField.getDimension()).thenReturn(1);
+        expectThrows(IllegalArgumentException.class, () -> knnQueryBuilder.doToQuery(mockQueryShardContext));
+    }
+
+    public void testDoToQuery_InvalidFieldType() throws IOException {
+        float[] queryVector = {1.0f, 2.0f, 3.0f, 4.0f};
+        KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder("mynumber", queryVector, 1);
+        Index dummyIndex = new Index("dummy", "dummy");
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        NumberFieldMapper.NumberFieldType mockNumberField = mock(NumberFieldMapper.NumberFieldType.class);
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockNumberField);
         expectThrows(IllegalArgumentException.class, () -> knnQueryBuilder.doToQuery(mockQueryShardContext));
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNQueryBuilderTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNQueryBuilderTests.java
@@ -21,7 +21,10 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.query.QueryShardContext;
-import org.mockito.Mockito;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class KNNQueryBuilderTests extends KNNTestCase {
 
@@ -79,15 +82,33 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         actualBuilder.equals(knnQueryBuilder);
     }
 
-    public void testDoToQuery() throws Exception {
+    public void testDoToQuery_Normal() throws Exception {
         float[] queryVector = {1.0f, 2.0f, 3.0f, 4.0f};
         KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder("myvector", queryVector, 1);
         Index dummyIndex = new Index("dummy", "dummy");
-        QueryShardContext mockQueryShardContext = Mockito.mock(QueryShardContext.class);
-        Mockito.when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        KNNVectorFieldMapper.KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        when(mockKNNVectorField.getDimension()).thenReturn(4);
+        when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
         KNNQuery query = (KNNQuery)knnQueryBuilder.doToQuery(mockQueryShardContext);
         assertEquals(knnQueryBuilder.getK(), query.getK());
         assertEquals(knnQueryBuilder.fieldName(), query.getField());
         assertEquals(knnQueryBuilder.vector(), query.getQueryVector());
+    }
+
+
+    public void testDoToQuery_InvalidDimensions() {
+        float[] queryVector = {1.0f, 2.0f, 3.0f, 4.0f};
+        KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder("myvector", queryVector, 1);
+        Index dummyIndex = new Index("dummy", "dummy");
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        KNNVectorFieldMapper.KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        when(mockKNNVectorField.getDimension()).thenReturn(400);
+        when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
+        expectThrows(IllegalArgumentException.class, () -> knnQueryBuilder.doToQuery(mockQueryShardContext));
+        when(mockKNNVectorField.getDimension()).thenReturn(1);
+        expectThrows(IllegalArgumentException.class, () -> knnQueryBuilder.doToQuery(mockQueryShardContext));
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
#211 

*Description of changes:*
Adds a dimension validation check in QueryBuilder class. This change catches invalid query dimensions sooner to prevent potential crash in JNI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
