### PR TITLE
Change score normalization for negative raw scores

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNWeight.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNWeight.java
@@ -127,7 +127,7 @@ public class KNNWeight extends Weight {
     public static float normalizeScore(float score) {
         if (score >= 0)
             return 1 / (1 + score);
-        return 2 + ( 1 / (score - 1) );
+        return -score + 1;
     }
 }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpace.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpace.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.knn.plugin.script;
 
+import com.amazon.opendistroforelasticsearch.knn.common.KNNConstants;
 import com.amazon.opendistroforelasticsearch.knn.index.KNNVectorFieldMapper;
 import com.amazon.opendistroforelasticsearch.knn.index.KNNWeight;
 import org.apache.lucene.index.LeafReaderContext;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpaceTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/plugin/script/KNNScoringSpaceTests.java
@@ -65,21 +65,38 @@ public class KNNScoringSpaceTests extends KNNTestCase {
     }
 
     public void testInnerProdSimilarity() {
-        float[] arrayFloat = new float[]{1.0f, 2.0f, 3.0f};
-        List<Double> arrayListQueryObject = new ArrayList<>(Arrays.asList(1.0, 2.0, 3.0));
-        float[] arrayFloat2 = new float[]{1.0f, 1.0f, 1.0f};
+        float[] arrayFloat_case1 = new float[]{1.0f, 2.0f, 3.0f};
+        List<Double> arrayListQueryObject_case1 = new ArrayList<>(Arrays.asList(1.0, 2.0, 3.0));
+        float[] arrayFloat2_case1 = new float[]{1.0f, 1.0f, 1.0f};
 
         KNNVectorFieldMapper.KNNVectorFieldType fieldType = new KNNVectorFieldMapper.KNNVectorFieldType("test",
                 Collections.emptyMap(), 3);
         KNNScoringSpace.InnerProd innerProd =
-                new KNNScoringSpace.InnerProd(arrayListQueryObject, fieldType);
+                new KNNScoringSpace.InnerProd(arrayListQueryObject_case1, fieldType);
 
-        assertEquals(1.857F, innerProd.scoringMethod.apply(arrayFloat2, arrayFloat), 0.001F);
+        assertEquals(7.0F, innerProd.scoringMethod.apply(arrayFloat_case1, arrayFloat2_case1), 0.001F);
+
+        float[] arrayFloat_case2 = new float[]{100_000.0f, 200_000.0f, 300_000.0f};
+        List<Double> arrayListQueryObject_case2 = new ArrayList<>(Arrays.asList(100_000.0, 200_000.0, 300_000.0));
+        float[] arrayFloat2_case2 = new float[]{-100_000.0f, -200_000.0f, -300_000.0f};
+
+        innerProd = new KNNScoringSpace.InnerProd(arrayListQueryObject_case2, fieldType);
+
+        assertEquals(7.142857143E-12F, innerProd.scoringMethod.apply(arrayFloat_case2, arrayFloat2_case2),
+                1.0E-11F);
+
+        float[] arrayFloat_case3 = new float[]{100_000.0f, 200_000.0f, 300_000.0f};
+        List<Double> arrayListQueryObject_case3 = new ArrayList<>(Arrays.asList(100_000.0, 200_000.0, 300_000.0));
+        float[] arrayFloat2_case3 = new float[]{100_000.0f, 200_000.0f, 300_000.0f};
+
+        innerProd = new KNNScoringSpace.InnerProd(arrayListQueryObject_case3, fieldType);
+
+        assertEquals(140_000_000_001F, innerProd.scoringMethod.apply(arrayFloat_case3, arrayFloat2_case3), 0.01F);
 
         NumberFieldMapper.NumberFieldType invalidFieldType = new NumberFieldMapper.NumberFieldType("field",
                 NumberFieldMapper.NumberType.INTEGER);
         expectThrows(IllegalArgumentException.class, () ->
-                new KNNScoringSpace.InnerProd(arrayListQueryObject, invalidFieldType));
+                new KNNScoringSpace.InnerProd(arrayListQueryObject_case2, invalidFieldType));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR changes the way in which we convert negative scores to positive scores for the inner product space.

Currently, we calculate it using the following function, where score maps to [-Float.MAX_VALUE, Float.MAX_VALUE]
```
        if (score >= 0)
            return 1 / (1 + score);
        return 2 + ( 1 / (score - 1) );
}
```
This function maps the score to [0, 2], where -Float.MAX_VALUE -> 2 and Float.MAX_VALUE -> 0. The problem with this function is that when score is a large negative number (say 20 million), ` ( 1 / (score - 1)` becomes very small. Then adding the number to 2 results in 2 instead of 1.999, leading to inaccuracy.

In this revision, we change the score function:
```
        if (score >= 0)
            return 1 / (1 + score);
        return -score + 1;
```

Now, if score is very large, it will still hold its value.

This approach still has the weakness that if score is very small (i.e. 0.000000000001), the results may just become 1. To prevent this, we could perform a more precise mapping of [-Float.MAX_VALUE, Float.MAX_VALUE] to [0, Float.MAX_VALUE] by shifting exponent of float by 1 and using most significant bit of exponent to determine "sign" and then setting sign bit to positive. However, this approach probably over complicates things and not be necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
