### PR TITLE
Expose getValue method from KNNScriptDocValues

### DIFF
--- a/src/main/resources/com/amazon/opendistroforelasticsearch/knn/plugin/script/knn_whitelist.txt
+++ b/src/main/resources/com/amazon/opendistroforelasticsearch/knn/plugin/script/knn_whitelist.txt
@@ -14,6 +14,7 @@
 # Painless definition of classes used by knn plugin
 
 class com.amazon.opendistroforelasticsearch.knn.index.KNNVectorScriptDocValues {
+  float[] getValue()
 }
 static_import {
   float l2Squared(List, com.amazon.opendistroforelasticsearch.knn.index.KNNVectorScriptDocValues) from_class com.amazon.opendistroforelasticsearch.knn.plugin.script.KNNScoringUtil


### PR DESCRIPTION
Since user might be interested in accessing the values directly,
allow getValue method. 
To use these in a script, leave out the get prefix and use value as a member variable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
